### PR TITLE
Added TIMEOUT in service_state

### DIFF
--- a/yasmin_ros/yasmin_ros/basic_outcomes.py
+++ b/yasmin_ros/yasmin_ros/basic_outcomes.py
@@ -17,3 +17,4 @@
 SUCCEED = "succeeded"
 ABORT = "aborted"
 CANCEL = "canceled"
+TIMEOUT = "timeout"


### PR DESCRIPTION
Added TIMEOUT outcome and use it in the service_state for timeout interruption.

This allows us to take decisions if the services are not yet available (e.g. try again, or launch the corresponding node, or simply abort, etc). The effect is left to the users of YASMIN, and therefore a different default outcome (TIMEOUT) was needed. 

These changes should not affect older code since the timeout is optional.

Hopefully is also useful for other people :-) rather than just for myself