### PR TITLE
Made throw exceptions more understandable

### DIFF
--- a/yasmin/include/yasmin/blackboard/blackboard.hpp
+++ b/yasmin/include/yasmin/blackboard/blackboard.hpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <exception>
 
 #include "yasmin/blackboard/blackboard_value.hpp"
 #include "yasmin/blackboard/blackboard_value_interface.hpp"
@@ -42,7 +43,7 @@ public:
     std::lock_guard<std::recursive_mutex> lk(this->mutex);
 
     if (!this->contains(name)) {
-      throw "Element " + name + " does not exist in the blackboard";
+      throw std::runtime_error("Element " + name + " does not exist in the blackboard");
     }
 
     BlackboardValue<T> *b_value = (BlackboardValue<T> *)this->values.at(name);

--- a/yasmin/src/yasmin/state.cpp
+++ b/yasmin/src/yasmin/state.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <exception>
 
 #include "yasmin/state.hpp"
 
@@ -30,7 +31,7 @@ State::operator()(std::shared_ptr<blackboard::Blackboard> blackboard) {
 
   if (std::find(this->outcomes.begin(), this->outcomes.end(), outcome) ==
       this->outcomes.end()) {
-    throw "Outcome (" + outcome + ") does not exist";
+    throw std::logic_error("Outcome (" + outcome + ") does not exist");
   }
 
   return outcome;

--- a/yasmin/src/yasmin/state_machine.cpp
+++ b/yasmin/src/yasmin/state_machine.cpp
@@ -17,7 +17,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -101,8 +101,8 @@ StateMachine::execute(std::shared_ptr<blackboard::Blackboard> blackboard) {
     // check outcome belongs to state
     if (std::find(state->get_outcomes().begin(), state->get_outcomes().end(),
                   outcome) == this->outcomes.end()) {
-      throw "Outcome (" + outcome + ") is not register in state " +
-          this->current_state;
+      throw std::logic_error("Outcome (" + outcome + ") is not register in state " +
+          this->current_state);
     }
 
     // translate outcome using transitions
@@ -133,7 +133,7 @@ StateMachine::execute(std::shared_ptr<blackboard::Blackboard> blackboard) {
 
       // outcome is not in the sm
     } else {
-      throw "Outcome (" + outcome + ") without transition";
+      throw std::logic_error("Outcome (" + outcome + ") without transition");
     }
   }
 


### PR DESCRIPTION
Hello,

This PR is for making throw exceptions more understandable by other users. With this changes,
We can print throw exceptions at terminal in a cool way. Would you like to show which command exactly you use for formatting so that i can be more careful about next PRs. (i know you use cmake format but i dunno what the exact command is)

From:

```sh
cihat@jarbay51:~/ws_yasmin$ ros2 run yasmin_demos yasmin_demo
yasmin_demo
Executing state FOO
terminate called after throwing an instance of 'std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >'
[ros2run]: Aborted

```

To:
```sh
cihat@jarbay51:~/ws_yasmin$ ros2 run yasmin_demos yasmin_demo
yasmin_demo
Executing state FOO
terminate called after throwing an instance of 'std::logic_error'
  what():  Outcome (outcome15) does not exist
[ros2run]: Aborted

```