### PR TITLE
fix(cancel): thread safety + allow overriding properly

### DIFF
--- a/yasmin/include/yasmin/state.hpp
+++ b/yasmin/include/yasmin/state.hpp
@@ -16,6 +16,7 @@
 #ifndef YASMIN_STATE_HPP
 #define YASMIN_STATE_HPP
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -30,7 +31,7 @@ protected:
   std::vector<std::string> outcomes;
 
 private:
-  bool canceled;
+  std::atomic_bool canceled{false};
 
 public:
   State(std::vector<std::string> outcomes);
@@ -43,8 +44,8 @@ public:
     return "";
   }
 
-  void cancel_state();
-  bool is_canceled();
+  virtual void cancel_state();
+  bool is_canceled() const;
 
   std::vector<std::string> const &get_outcomes();
 

--- a/yasmin/include/yasmin/state_machine.hpp
+++ b/yasmin/include/yasmin/state_machine.hpp
@@ -39,7 +39,7 @@ public:
   void set_start_state(std::string state_name);
   std::string get_start_state();
 
-  void cancel_state();
+  void cancel_state() override;
 
   std::map<std::string, std::shared_ptr<State>> const &get_states();
   std::map<std::string, std::map<std::string, std::string>> const &

--- a/yasmin/src/yasmin/state.cpp
+++ b/yasmin/src/yasmin/state.cpp
@@ -27,7 +27,7 @@ State::State(std::vector<std::string> outcomes) { this->outcomes = outcomes; }
 
 std::string
 State::operator()(std::shared_ptr<blackboard::Blackboard> blackboard) {
-  this->canceled = false;
+  this->canceled.store(false);
   std::string outcome = this->execute(blackboard);
 
   if (std::find(this->outcomes.begin(), this->outcomes.end(), outcome) ==
@@ -38,8 +38,8 @@ State::operator()(std::shared_ptr<blackboard::Blackboard> blackboard) {
   return outcome;
 }
 
-void State::cancel_state() { this->canceled = true; }
+void State::cancel_state() { this->canceled.store(true); }
 
-bool State::is_canceled() { return this->canceled; }
+bool State::is_canceled() const { return this->canceled.load(); }
 
 std::vector<std::string> const &State::get_outcomes() { return this->outcomes; }


### PR DESCRIPTION
Cancel functionality was not thread safe and the override functionality did not work for the `StateMachine`.