### PR TITLE
Preempt monitor state on cancel request

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ def main():
             "outcome1": "PRINTING_ODOM",
             "outcome2": "outcome4",
             TIMEOUT: "outcome4",
+            CANCEL: "outcome4",
         },
     )
 

--- a/yasmin_demos/src/monitor_demo.cpp
+++ b/yasmin_demos/src/monitor_demo.cpp
@@ -141,6 +141,8 @@ int main(int argc, char *argv[]) {
           {"outcome2", "outcome4"}, // Transition to outcome4 on outcome2
           {yasmin_ros::basic_outcomes::TIMEOUT,
            "outcome4"}, // Timeout transition
+          {yasmin_ros::basic_outcomes::CANCEL,
+           "outcome4"}, // Cancel transition
       });
 
   // Publisher for visualizing the state machine's status

--- a/yasmin_demos/yasmin_demos/monitor_demo.py
+++ b/yasmin_demos/yasmin_demos/monitor_demo.py
@@ -24,7 +24,7 @@ from yasmin import Blackboard
 from yasmin import StateMachine
 from yasmin_ros import MonitorState
 from yasmin_ros import set_ros_loggers
-from yasmin_ros.basic_outcomes import TIMEOUT
+from yasmin_ros.basic_outcomes import TIMEOUT, CANCEL
 from yasmin_viewer import YasminViewerPub
 
 
@@ -128,6 +128,7 @@ def main():
             "outcome1": "PRINTING_ODOM",
             "outcome2": "outcome4",
             TIMEOUT: "outcome4",
+            CANCEL: "outcome4",
         },
     )
 

--- a/yasmin_ros/include/yasmin_ros/monitor_state.hpp
+++ b/yasmin_ros/include/yasmin_ros/monitor_state.hpp
@@ -154,6 +154,11 @@ public:
       std::this_thread::sleep_for(
           std::chrono::microseconds(this->time_to_wait));
 
+      if (is_canceled()) {
+        this->monitoring = false;
+        return basic_outcomes::CANCEL;
+      }
+
       if (this->timeout > 0) {
 
         if (elapsed_time / 1e6 >= this->timeout) {

--- a/yasmin_ros/include/yasmin_ros/monitor_state.hpp
+++ b/yasmin_ros/include/yasmin_ros/monitor_state.hpp
@@ -118,6 +118,7 @@ public:
     } else {
       this->outcomes = {};
     }
+    this->outcomes.insert(basic_outcomes::CANCEL);
 
     if (outcomes.size() > 0) {
       for (std::string outcome : outcomes) {

--- a/yasmin_ros/yasmin_ros/monitor_state.py
+++ b/yasmin_ros/yasmin_ros/monitor_state.py
@@ -23,7 +23,7 @@ from rclpy.qos import QoSProfile
 from yasmin import State
 from yasmin import Blackboard
 from yasmin_ros.yasmin_node import YasminNode
-from yasmin_ros.basic_outcomes import TIMEOUT
+from yasmin_ros.basic_outcomes import TIMEOUT, CANCEL
 
 
 class MonitorState(State):
@@ -89,6 +89,7 @@ class MonitorState(State):
 
         if timeout is not None:
             outcomes = [TIMEOUT] + outcomes
+        outcomes = [CANCEL] + outcomes
 
         ## The ROS 2 node instance used for subscriptions.
         self._node: Node = node
@@ -149,6 +150,10 @@ class MonitorState(State):
         # Wait until a message is received or timeout is reached
         while not self.msg_list:
             time.sleep(self.time_to_wait)
+
+            if self.is_canceled():
+                self.monitoring: bool = False
+                return CANCEL
 
             if self._timeout is not None:
                 if elapsed_time >= self._timeout:


### PR DESCRIPTION
The `monitor_state` remains active when canceled.
To prevent this, I suggest checking for cancellation in the execute method.