### PR TITLE
Set remappings as empty dict instead of None

### DIFF
--- a/yasmin/yasmin/state_machine.py
+++ b/yasmin/yasmin/state_machine.py
@@ -386,7 +386,7 @@ class StateMachine(State):
             if self.get_current_state() in self.__remappings:
                 blackboard.remappings = self.__remappings[self.get_current_state()]
             else:
-                blackboard.remappings = None
+                blackboard.remappings = dict()
             outcome = state["state"](blackboard)
             old_outcome = outcome
             # Check if outcome belongs to state


### PR DESCRIPTION
This issue was introduced in https://github.com/uleroboticsgroup/yasmin/pull/47

The remappings of the blackboard are setting to None, so it raises the `AttributeError` commented in https://github.com/uleroboticsgroup/yasmin/issues/48

Closes https://github.com/uleroboticsgroup/yasmin/issues/48 
