### PR TITLE
Fix python YASMIN_LOG_ERROR method

### DIFF
--- a/yasmin/yasmin/logs.py
+++ b/yasmin/yasmin/logs.py
@@ -174,7 +174,8 @@ def YASMIN_LOG_ERROR(text: str) -> None:
 
     @return: None
     """
-    log_helper(LogLevel.ERROR, text)
+    file, function, line = get_caller_info()
+    log_helper(LogLevel.ERROR, file, function, line, text)
 
 
 def YASMIN_LOG_WARN(text: str) -> None:


### PR DESCRIPTION
All the loggers were updated to use the new yasmin logs in https://github.com/uleroboticsgroup/yasmin/commit/a19dda53c218810e2201530156b29725b8ae202a, but the `YASMIN_LOG_ERROR` method is missing some arguments when using `log_helper`:

```
Traceback (most recent call last):
  File "/home/noeljg/sm_ws/install/advanced_navigation/lib/advanced_navigation/advanced_navigation_sm", line 33, in <module>
    sys.exit(load_entry_point('advanced-navigation', 'console_scripts', 'advanced_navigation_sm')())
  File "/home/noeljg/sm_ws/build/advanced_navigation/advanced_navigation/advanced_navigation_sm.py", line 48, in main
    YASMIN_LOG_ERROR("This is a test log message with level ERROR")
  File "/home/noeljg/sm_ws/install/yasmin/local/lib/python3.10/dist-packages/yasmin/logs.py", line 177, in YASMIN_LOG_ERROR
    log_helper(LogLevel.ERROR, text)
TypeError: log_helper() missing 3 required positional arguments: 'function', 'line', and 'text'
```

This PR solves the issue.