### PR TITLE
Declare states outside the state_machine

### DIFF
--- a/yasmin_demos/CMakeLists.txt
+++ b/yasmin_demos/CMakeLists.txt
@@ -184,6 +184,11 @@ install(PROGRAMS
 )
 
 install(PROGRAMS
+  yasmin_demos/multiple_states_demo.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(PROGRAMS
   yasmin_demos/concurrence_demo.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/yasmin_demos/CMakeLists.txt
+++ b/yasmin_demos/CMakeLists.txt
@@ -52,6 +52,10 @@ include_directories(include)
 include_directories(src)
 
 set(LIB ${CMAKE_PROJECT_NAME}_lib)
+set(SOURCES
+  src/foo_state.cpp
+  src/bar_state.cpp
+)
 set(DEPENDENCIES
   rclcpp
   rclcpp_action
@@ -60,6 +64,13 @@ set(DEPENDENCIES
   yasmin_viewer
   nav_msgs
   example_interfaces
+)
+
+add_library(${LIB} STATIC ${SOURCES})
+ament_target_dependencies(${LIB} ${DEPENDENCIES})
+
+install(DIRECTORY include/
+  DESTINATION include/
 )
 
 # demo
@@ -118,9 +129,18 @@ fibonacci_action_server
   DESTINATION lib/${PROJECT_NAME}
 )
 
+# multiple_states_demos
+add_executable(multiple_states_demo src/multiple_states_demo.cpp)
+ament_target_dependencies(multiple_states_demo ${DEPENDENCIES})
+target_link_libraries(multiple_states_demo ${LIB})
+install(TARGETS
+  multiple_states_demo
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_export_include_directories(include)
 ament_export_libraries(${LIB})
-
+ament_export_dependencies(${DEPENDENCIES})
 
 # Python
 ament_python_install_package(${PROJECT_NAME})

--- a/yasmin_demos/include/yasmin_demos/bar_state.h
+++ b/yasmin_demos/include/yasmin_demos/bar_state.h
@@ -1,0 +1,15 @@
+#include <string>
+
+#ifndef BAR_STATE_H
+#define BAR_STATE_H
+
+class BarState: public yasmin::State {
+public:
+    BarState();
+    ~BarState();
+
+    std::string execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
+
+};
+
+#endif // BAR_STATE_H

--- a/yasmin_demos/include/yasmin_demos/bar_state.h
+++ b/yasmin_demos/include/yasmin_demos/bar_state.h
@@ -3,12 +3,13 @@
 #ifndef BAR_STATE_H
 #define BAR_STATE_H
 
-class BarState: public yasmin::State {
+class BarState : public yasmin::State {
 public:
-    BarState();
-    ~BarState();
+  BarState();
+  ~BarState();
 
-    std::string execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
+  std::string
+  execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
 
 };
 

--- a/yasmin_demos/include/yasmin_demos/bar_state.h
+++ b/yasmin_demos/include/yasmin_demos/bar_state.h
@@ -10,7 +10,6 @@ public:
 
   std::string
   execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
-
 };
 
 #endif // BAR_STATE_H

--- a/yasmin_demos/include/yasmin_demos/bar_state.h
+++ b/yasmin_demos/include/yasmin_demos/bar_state.h
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Pedro Edom Nunes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <string>
 
 #ifndef BAR_STATE_H

--- a/yasmin_demos/include/yasmin_demos/foo_state.h
+++ b/yasmin_demos/include/yasmin_demos/foo_state.h
@@ -1,0 +1,16 @@
+#include <string>
+
+#ifndef YASMIN_DEMOS_FOO_STATE_H
+#define YASMIN_DEMOS_FOO_STATE_H
+
+class FooState: public yasmin::State {
+public:
+    FooState();
+    ~FooState();
+
+    std::string execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
+    int counter;
+
+};
+
+#endif // YASMIN_DEMOS_FOO_STATE_H

--- a/yasmin_demos/include/yasmin_demos/foo_state.h
+++ b/yasmin_demos/include/yasmin_demos/foo_state.h
@@ -3,13 +3,14 @@
 #ifndef YASMIN_DEMOS_FOO_STATE_H
 #define YASMIN_DEMOS_FOO_STATE_H
 
-class FooState: public yasmin::State {
+class FooState : public yasmin::State {
 public:
-    FooState();
-    ~FooState();
+  FooState();
+  ~FooState();
 
-    std::string execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
-    int counter;
+  std::string
+  execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
+  int counter;
 
 };
 

--- a/yasmin_demos/include/yasmin_demos/foo_state.h
+++ b/yasmin_demos/include/yasmin_demos/foo_state.h
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Pedro Edom Nunes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <string>
 
 #ifndef YASMIN_DEMOS_FOO_STATE_H

--- a/yasmin_demos/include/yasmin_demos/foo_state.h
+++ b/yasmin_demos/include/yasmin_demos/foo_state.h
@@ -11,7 +11,6 @@ public:
   std::string
   execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard);
   int counter;
-
 };
 
 #endif // YASMIN_DEMOS_FOO_STATE_H

--- a/yasmin_demos/src/bar_state.cpp
+++ b/yasmin_demos/src/bar_state.cpp
@@ -7,8 +7,8 @@
 #include "yasmin/logs.hpp"
 #include "yasmin/state.hpp"
 #include "yasmin/state_machine.hpp"
-#include "yasmin_ros/ros_logs.hpp"
 #include "yasmin_demos/bar_state.h"
+#include "yasmin_ros/ros_logs.hpp"
 
 using namespace yasmin;
 
@@ -20,22 +20,23 @@ using namespace yasmin;
  */
 BarState::BarState() : yasmin::State({"outcome3"}) {};
     
-  /**
-   * @brief Executes the Bar state logic.
-   *
-   * This method logs the execution, waits for 3 seconds,
-   * retrieves a string from the blackboard, and logs it.
-   *
-   * @param blackboard Shared pointer to the blackboard for state communication.
-   * @return std::string The outcome of the execution: "outcome3".
-   */
-  std::string BarState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
-    YASMIN_LOG_INFO("Executing state BAR");
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+/**
+ * @brief Executes the Bar state logic.
+ *
+ * This method logs the execution, waits for 3 seconds,
+ * retrieves a string from the blackboard, and logs it.
+ *
+ * @param blackboard Shared pointer to the blackboard for state communication.
+ * @return std::string The outcome of the execution: "outcome3".
+ */
+std::string 
+BarState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
+  YASMIN_LOG_INFO("Executing state BAR");
+  std::this_thread::sleep_for(std::chrono::seconds(3));
 
-    YASMIN_LOG_INFO(blackboard->get<std::string>("foo_str").c_str());
+  YASMIN_LOG_INFO(blackboard->get<std::string>("foo_str").c_str());
 
-    return "outcome3";
-  };
+  return "outcome3";
+};
 
-  BarState::~BarState() {};
+BarState::~BarState(){};

--- a/yasmin_demos/src/bar_state.cpp
+++ b/yasmin_demos/src/bar_state.cpp
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Pedro Edom Nunes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <chrono>
 #include <iostream>
 #include <memory>

--- a/yasmin_demos/src/bar_state.cpp
+++ b/yasmin_demos/src/bar_state.cpp
@@ -18,8 +18,8 @@ using namespace yasmin;
  * This state logs the value from the blackboard and provides
  * a single outcome to transition.
  */
-BarState::BarState() : yasmin::State({"outcome3"}) {};
-    
+BarState::BarState() : yasmin::State({"outcome3"}){};
+
 /**
  * @brief Executes the Bar state logic.
  *
@@ -29,7 +29,7 @@ BarState::BarState() : yasmin::State({"outcome3"}) {};
  * @param blackboard Shared pointer to the blackboard for state communication.
  * @return std::string The outcome of the execution: "outcome3".
  */
-std::string 
+std::string
 BarState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
   YASMIN_LOG_INFO("Executing state BAR");
   std::this_thread::sleep_for(std::chrono::seconds(3));

--- a/yasmin_demos/src/bar_state.cpp
+++ b/yasmin_demos/src/bar_state.cpp
@@ -1,0 +1,41 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "yasmin/logs.hpp"
+#include "yasmin/state.hpp"
+#include "yasmin/state_machine.hpp"
+#include "yasmin_ros/ros_logs.hpp"
+#include "yasmin_demos/bar_state.h"
+
+using namespace yasmin;
+
+/**
+ * @brief Represents the "Bar" state in the state machine.
+ *
+ * This state logs the value from the blackboard and provides
+ * a single outcome to transition.
+ */
+BarState::BarState() : yasmin::State({"outcome3"}) {};
+    
+  /**
+   * @brief Executes the Bar state logic.
+   *
+   * This method logs the execution, waits for 3 seconds,
+   * retrieves a string from the blackboard, and logs it.
+   *
+   * @param blackboard Shared pointer to the blackboard for state communication.
+   * @return std::string The outcome of the execution: "outcome3".
+   */
+  std::string BarState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
+    YASMIN_LOG_INFO("Executing state BAR");
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    YASMIN_LOG_INFO(blackboard->get<std::string>("foo_str").c_str());
+
+    return "outcome3";
+  };
+
+  BarState::~BarState() {};

--- a/yasmin_demos/src/foo_state.cpp
+++ b/yasmin_demos/src/foo_state.cpp
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Pedro Edom Nunes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <chrono>
 #include <iostream>
 #include <memory>

--- a/yasmin_demos/src/foo_state.cpp
+++ b/yasmin_demos/src/foo_state.cpp
@@ -31,7 +31,7 @@ FooState::FooState() : yasmin::State({"outcome1", "outcome2"}) { counter = 0; };
  * @param blackboard Shared pointer to the blackboard for state communication.
  * @return std::string The outcome of the execution: "outcome1" or "outcome2".
  */
-std::string 
+std::string
 FooState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
   YASMIN_LOG_INFO("Executing state FOO");
   std::this_thread::sleep_for(std::chrono::seconds(3));
@@ -39,7 +39,7 @@ FooState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
   if (this->counter < 3) {
     this->counter += 1;
     blackboard->set<std::string>("foo_str",
-                                  "Counter: " + std::to_string(this->counter));
+                                 "Counter: " + std::to_string(this->counter));
     return "outcome1";
 
   } else {

--- a/yasmin_demos/src/foo_state.cpp
+++ b/yasmin_demos/src/foo_state.cpp
@@ -1,0 +1,51 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "yasmin/logs.hpp"
+#include "yasmin/state.hpp"
+#include "yasmin/state_machine.hpp"
+#include "yasmin_ros/ros_logs.hpp"
+#include "yasmin_demos/foo_state.h"
+
+using namespace yasmin;
+
+/**
+ * @brief Represents the "Foo" state in the state machine.
+ *
+ * This state increments a counter each time it is executed and
+ * communicates the current count via the blackboard.
+ */
+FooState::FooState() : yasmin::State({"outcome1", "outcome2"}) {
+    counter = 0;
+};
+
+  /**
+   * @brief Executes the Foo state logic.
+   *
+   * This method logs the execution, waits for 3 seconds,
+   * increments the counter, and sets a string in the blackboard.
+   * The state will transition to either "outcome1" or "outcome2"
+   * based on the current value of the counter.
+   *
+   * @param blackboard Shared pointer to the blackboard for state communication.
+   * @return std::string The outcome of the execution: "outcome1" or "outcome2".
+   */
+  std::string FooState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
+    YASMIN_LOG_INFO("Executing state FOO");
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    if (this->counter < 3) {
+      this->counter += 1;
+      blackboard->set<std::string>("foo_str",
+                                   "Counter: " + std::to_string(this->counter));
+      return "outcome1";
+
+    } else {
+      return "outcome2";
+    }
+  };
+
+  FooState::~FooState() {};

--- a/yasmin_demos/src/foo_state.cpp
+++ b/yasmin_demos/src/foo_state.cpp
@@ -7,8 +7,8 @@
 #include "yasmin/logs.hpp"
 #include "yasmin/state.hpp"
 #include "yasmin/state_machine.hpp"
-#include "yasmin_ros/ros_logs.hpp"
 #include "yasmin_demos/foo_state.h"
+#include "yasmin_ros/ros_logs.hpp"
 
 using namespace yasmin;
 
@@ -18,34 +18,33 @@ using namespace yasmin;
  * This state increments a counter each time it is executed and
  * communicates the current count via the blackboard.
  */
-FooState::FooState() : yasmin::State({"outcome1", "outcome2"}) {
-    counter = 0;
+FooState::FooState() : yasmin::State({"outcome1", "outcome2"}) { counter = 0; };
+
+/**
+ * @brief Executes the Foo state logic.
+ *
+ * This method logs the execution, waits for 3 seconds,
+ * increments the counter, and sets a string in the blackboard.
+ * The state will transition to either "outcome1" or "outcome2"
+ * based on the current value of the counter.
+ *
+ * @param blackboard Shared pointer to the blackboard for state communication.
+ * @return std::string The outcome of the execution: "outcome1" or "outcome2".
+ */
+std::string 
+FooState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
+  YASMIN_LOG_INFO("Executing state FOO");
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+
+  if (this->counter < 3) {
+    this->counter += 1;
+    blackboard->set<std::string>("foo_str",
+                                  "Counter: " + std::to_string(this->counter));
+    return "outcome1";
+
+  } else {
+    return "outcome2";
+  }
 };
 
-  /**
-   * @brief Executes the Foo state logic.
-   *
-   * This method logs the execution, waits for 3 seconds,
-   * increments the counter, and sets a string in the blackboard.
-   * The state will transition to either "outcome1" or "outcome2"
-   * based on the current value of the counter.
-   *
-   * @param blackboard Shared pointer to the blackboard for state communication.
-   * @return std::string The outcome of the execution: "outcome1" or "outcome2".
-   */
-  std::string FooState::execute(std::shared_ptr<yasmin::blackboard::Blackboard> blackboard) {
-    YASMIN_LOG_INFO("Executing state FOO");
-    std::this_thread::sleep_for(std::chrono::seconds(3));
-
-    if (this->counter < 3) {
-      this->counter += 1;
-      blackboard->set<std::string>("foo_str",
-                                   "Counter: " + std::to_string(this->counter));
-      return "outcome1";
-
-    } else {
-      return "outcome2";
-    }
-  };
-
-  FooState::~FooState() {};
+FooState::~FooState(){};

--- a/yasmin_demos/src/multiple_states_demo.cpp
+++ b/yasmin_demos/src/multiple_states_demo.cpp
@@ -1,3 +1,18 @@
+// Copyright (C) 2025 Pedro Edom Nunes
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"

--- a/yasmin_demos/src/multiple_states_demo.cpp
+++ b/yasmin_demos/src/multiple_states_demo.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2023 Miguel Ángel González Santamarta
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "yasmin/logs.hpp"
+#include "yasmin/state.hpp"
+#include "yasmin/state_machine.hpp"
+#include "yasmin_ros/ros_logs.hpp"
+#include "yasmin_demos/bar_state.h"
+#include "yasmin_demos/foo_state.h"
+// #include "yasmin_viewer/yasmin_viewer_pub.hpp"
+
+using namespace yasmin;
+
+/**
+ * @brief Main function that initializes the ROS 2 node and state machine.
+ *
+ * This function sets up the state machine, adds states, and handles
+ * the execution flow, including logging and cleanup.
+ *
+ * @param argc Argument count from the command line.
+ * @param argv Argument vector from the command line.
+ * @return int Exit status of the program. Returns 0 on success.
+ *
+ * @throws std::exception If there is an error during state machine execution.
+ */
+int main(int argc, char *argv[]) {
+  YASMIN_LOG_INFO("multiple_states_demo");
+  rclcpp::init(argc, argv);
+
+  // Set ROS 2 logs
+  yasmin_ros::set_ros_loggers();
+
+  // Create a state machine
+  auto sm = std::make_shared<yasmin::StateMachine>(
+      std::initializer_list<std::string>{"outcome4"});
+
+  // Cancel state machine on ROS 2 shutdown
+  rclcpp::on_shutdown([sm]() {
+    if (sm->is_running()) {
+      sm->cancel_state();
+    }
+  });
+
+  // Add states to the state machine
+  sm->add_state("FOO", std::make_shared<FooState>(),
+                {
+                    {"outcome1", "BAR"},
+                    {"outcome2", "outcome4"},
+                });
+  sm->add_state("BAR", std::make_shared<BarState>(),
+                {
+                    {"outcome3", "FOO"},
+                });
+
+  // Execute the state machine
+  try {
+    std::string outcome = (*sm.get())();
+    YASMIN_LOG_INFO(outcome.c_str());
+  } catch (const std::exception &e) {
+    YASMIN_LOG_WARN(e.what());
+  }
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/yasmin_demos/src/multiple_states_demo.cpp
+++ b/yasmin_demos/src/multiple_states_demo.cpp
@@ -1,21 +1,3 @@
-// Copyright (C) 2023 Miguel Ángel González Santamarta
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-#include <chrono>
-#include <iostream>
-#include <memory>
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
@@ -25,7 +7,6 @@
 #include "yasmin_ros/ros_logs.hpp"
 #include "yasmin_demos/bar_state.h"
 #include "yasmin_demos/foo_state.h"
-// #include "yasmin_viewer/yasmin_viewer_pub.hpp"
 
 using namespace yasmin;
 

--- a/yasmin_demos/src/multiple_states_demo.cpp
+++ b/yasmin_demos/src/multiple_states_demo.cpp
@@ -4,9 +4,9 @@
 #include "yasmin/logs.hpp"
 #include "yasmin/state.hpp"
 #include "yasmin/state_machine.hpp"
-#include "yasmin_ros/ros_logs.hpp"
 #include "yasmin_demos/bar_state.h"
 #include "yasmin_demos/foo_state.h"
+#include "yasmin_ros/ros_logs.hpp"
 
 using namespace yasmin;
 

--- a/yasmin_demos/yasmin_demos/__init__.py
+++ b/yasmin_demos/yasmin_demos/__init__.py
@@ -1,0 +1,2 @@
+from yasmin_demos.foo_state import FooState
+from yasmin_demos.bar_state import BarState

--- a/yasmin_demos/yasmin_demos/bar_state.py
+++ b/yasmin_demos/yasmin_demos/bar_state.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 #coding: utf-8
 
+# Copyright (C) 2025 Pedro Edom Nunes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import time
 import rclpy
 

--- a/yasmin_demos/yasmin_demos/bar_state.py
+++ b/yasmin_demos/yasmin_demos/bar_state.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#coding: utf-8
+
+import time
+import rclpy
+
+import yasmin
+from yasmin import State
+from yasmin import Blackboard
+
+# Define the BarState class, inheriting from the State class
+class BarState(State):
+    """
+    Represents the Bar state in the state machine.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the BarState instance, setting up the outcome.
+
+        Outcomes:
+            outcome3: Indicates the state should transition back to the Foo state.
+        """
+        super().__init__(outcomes=["outcome3"])
+
+    def execute(self, blackboard: Blackboard) -> str:
+        """
+        Executes the logic for the Bar state.
+
+        Args:
+            blackboard (Blackboard): The shared data structure for states.
+
+        Returns:
+            str: The outcome of the execution, which will always be "outcome3".
+
+        Raises:
+            Exception: May raise exceptions related to state execution.
+        """
+        yasmin.YASMIN_LOG_INFO("Executing state BAR")
+        time.sleep(3)  # Simulate work by sleeping
+
+        yasmin.YASMIN_LOG_INFO(blackboard["foo_str"])
+        return "outcome3"

--- a/yasmin_demos/yasmin_demos/foo_state.py
+++ b/yasmin_demos/yasmin_demos/foo_state.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 #coding: utf-8
 
+# Copyright (C) 2025 Pedro Edom Nunes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import time
 import rclpy
 

--- a/yasmin_demos/yasmin_demos/foo_state.py
+++ b/yasmin_demos/yasmin_demos/foo_state.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#coding: utf-8
+
+import time
+import rclpy
+
+import yasmin
+from yasmin import State
+from yasmin import Blackboard
+
+# Define the FooState class, inheriting from the State class
+class FooState(State):
+    """
+    Represents the Foo state in the state machine.
+
+    Attributes:
+        counter (int): Counter to track the number of executions of this state.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initializes the FooState instance, setting up the outcomes.
+
+        Outcomes:
+            outcome1: Indicates the state should continue to the Bar state.
+            outcome2: Indicates the state should finish execution and return.
+        """
+        super().__init__(["outcome1", "outcome2"])
+        self.counter = 0
+
+    def execute(self, blackboard: Blackboard) -> str:
+        """
+        Executes the logic for the Foo state.
+
+        Args:
+            blackboard (Blackboard): The shared data structure for states.
+
+        Returns:
+            str: The outcome of the execution, which can be "outcome1" or "outcome2".
+
+        Raises:
+            Exception: May raise exceptions related to state execution.
+        """
+        yasmin.YASMIN_LOG_INFO("Executing state FOO")
+        time.sleep(3)  # Simulate work by sleeping
+
+        if self.counter < 3:
+            self.counter += 1
+            blackboard["foo_str"] = f"Counter: {self.counter}"
+            return "outcome1"
+        else:
+            return "outcome2"

--- a/yasmin_demos/yasmin_demos/multiple_states_demo.py
+++ b/yasmin_demos/yasmin_demos/multiple_states_demo.py
@@ -1,6 +1,21 @@
 #!/usr/bin/env python3
 #coding: utf-8
 
+# Copyright (C) 2025 Pedro Edom Nunes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import time
 import rclpy
 

--- a/yasmin_demos/yasmin_demos/multiple_states_demo.py
+++ b/yasmin_demos/yasmin_demos/multiple_states_demo.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#coding: utf-8
+
+import time
+import rclpy
+
+import yasmin
+from yasmin import State
+from yasmin import Blackboard
+from yasmin import StateMachine
+from yasmin_ros import set_ros_loggers
+from yasmin_viewer import YasminViewerPub
+from yasmin_demos import FooState, BarState
+
+# Main function to initialize and run the state machine
+def main():
+    """
+    The main entry point of the application.
+
+    Initializes the ROS 2 environment, sets up the state machine,
+    and handles execution and termination.
+
+    Raises:
+        KeyboardInterrupt: If the execution is interrupted by the user.
+    """
+    yasmin.YASMIN_LOG_INFO("yasmin_demo")
+
+    # Initialize ROS 2
+    rclpy.init()
+
+    # Set ROS 2 loggers
+    set_ros_loggers()
+
+    # Create a finite state machine (FSM)
+    sm = StateMachine(outcomes=["outcome4"])
+
+    # Add states to the FSM
+    sm.add_state(
+        "FOO",
+        FooState(),
+        transitions={
+            "outcome1": "BAR",
+            "outcome2": "outcome4",
+        },
+    )
+    sm.add_state(
+        "BAR",
+        BarState(),
+        transitions={
+            "outcome3": "FOO",
+        },
+    )
+
+    # Publish FSM information for visualization
+    YasminViewerPub("yasmin_demo", sm)
+
+    # Execute the FSM
+    try:
+        outcome = sm()
+        yasmin.YASMIN_LOG_INFO(outcome)
+    except KeyboardInterrupt:
+        if sm.is_running():
+            sm.cancel_state()
+
+    # Shutdown ROS 2 if it's running
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR implements a demos to handler multiple states declare outside the main state machine file. With this it is possible to create many states and keep it simple and organized and then only import the used states to the main file.