### PR TITLE
Pass current state instead of start state to transition cb

### DIFF
--- a/yasmin/src/yasmin/state_machine.cpp
+++ b/yasmin/src/yasmin/state_machine.cpp
@@ -348,7 +348,7 @@ StateMachine::execute(std::shared_ptr<blackboard::Blackboard> blackboard) {
       YASMIN_LOG_INFO("State machine transitioning '%s' : '%s' --> '%s'",
                       this->current_state.c_str(), old_outcome.c_str(),
                       outcome.c_str());
-      this->call_transition_cbs(blackboard, this->get_start_state(), outcome,
+      this->call_transition_cbs(blackboard, this->current_state, outcome,
                                 old_outcome);
 
       this->current_state_mutex->lock();


### PR DESCRIPTION
Currently the state machine's start state is passed to the transition callback, instead of the intended "from_state".
This differs from the signature of `call_transition_cbs()` and the python implementation