### PR TITLE
Add FAIL to basic outcomes

### DIFF
--- a/yasmin_ros/yasmin_ros/basic_outcomes.py
+++ b/yasmin_ros/yasmin_ros/basic_outcomes.py
@@ -22,5 +22,6 @@ be utilized for error handling, logging, and user feedback.
 # Constants representing the various status codes
 SUCCEED = "succeeded"  ##< Indicates that an operation has completed successfully.
 ABORT = "aborted"  ##< Indicates that an operation was aborted before completion.
+FAIL =  "failed"  ##< Indicates that an operation has not achieved its intended result.
 CANCEL = "canceled"  ##< Indicates that an operation was canceled by the user or system.
 TIMEOUT = "timeout"  ##< Indicates that an operation has timed out and did not complete in a timely manner.


### PR DESCRIPTION
I suggest adding a FAIL to basic_outcomes to serve as the opposite to SUCCEED. While ABORT works as the basic outcome for the state encountering an error and finishing before completion, I think FAIL would be a good addition for states in which no error occurred, but they failed to achieve their intended result (e.g. checking if a number is even, a Counter state not reaching its goal).

Example usage: 

```python
class CheckIfIntIsEven(State):

    def __init__(self, number) -> None:
        super().__init__(outcomes=[SUCCEED, ABORT,])
        self.number = number

    def execute(self, blackboard: Blackboard) -> str:
        if type(self.number) == int:
            if self.number % 2 == 0:
                return SUCCEED
            else:
                return FAIL
        else:
            yasmin.YASMIN_LOG_ERROR("Given number is not an int.")
            return ABORT
```