### PR TITLE
Fixing set log level in Cpp

### DIFF
--- a/yasmin/include/yasmin/logs.hpp
+++ b/yasmin/include/yasmin/logs.hpp
@@ -59,9 +59,9 @@ extern LogLevel log_level;
  * This function allows the user to specify the log level error, warning, info,
  * or debug.
  *
- * @param log_level Log level.
+ * @param new_log_level Log level.
  */
-void set_log_level(LogLevel level);
+void set_log_level(LogLevel new_log_level);
 
 /**
  * @brief Parse LogLevel to string.

--- a/yasmin/src/yasmin/logs.cpp
+++ b/yasmin/src/yasmin/logs.cpp
@@ -42,7 +42,7 @@ LogLevel log_level = INFO;
 
 LogFunction log_message = default_log_message;
 
-void set_log_level(LogLevel log_level) { log_level = log_level; }
+void set_log_level(LogLevel new_log_level) { log_level = new_log_level; }
 
 const char *log_level_to_name(LogLevel log_level) {
   switch (log_level) {


### PR DESCRIPTION
The variable set by set_log_level has the same name inside and outside the set function. So when setting the variable, the parameter of the functio is set and not the global variable(More info about variable scoping in c++ https://www.w3schools.com/cpp/cpp_scope.asp).

This merge request fix the error and make the set_log_level working.
