### PR TITLE
Fix re-entering concurrent states after a cancel by using the () operator instead of execute() function

### DIFF
--- a/yasmin/include/yasmin/concurrence.hpp
+++ b/yasmin/include/yasmin/concurrence.hpp
@@ -70,11 +70,6 @@ protected:
   std::set<std::string> possible_outcomes;
 
 private:
-  /// Indicates if the state has been canceled.
-  std::atomic_bool canceled{false};
-  /// Indicates if the state is currently running.
-  std::atomic_bool running{false};
-
   /// Mutex for intermediate outcome map
   std::mutex intermediate_outcome_mutex;
 

--- a/yasmin/src/yasmin/concurrence.cpp
+++ b/yasmin/src/yasmin/concurrence.cpp
@@ -70,7 +70,7 @@ Concurrence::execute(std::shared_ptr<blackboard::Blackboard> blackboard) {
   // Initialize the parallel execution of all the states
   for (std::shared_ptr<State> state : states) {
     state_threads.push_back(std::thread([this, state, blackboard]() {
-      std::string outcome = state->execute(blackboard);
+      std::string outcome = (*state.get())(blackboard);
       const std::lock_guard<std::mutex> lock(this->intermediate_outcome_mutex);
       this->intermediate_outcome_map[state] =
           std::make_shared<std::string>(outcome);


### PR DESCRIPTION
Nice work on getting concurrence into Yasmin.
However, I noticed that when a concurrence state is cancelled and re-entered at a later stage, all states wrapped in the concurrence-state still have the `canceled` flag set.

In a normal statemachine, a state is executed by calling the `()` operator instead of the `execute()` function directly: https://github.com/uleroboticsgroup/yasmin/blob/983a0153057f98ccb95427d79a50610c43d4b3a5/yasmin/src/yasmin/state_machine.cpp#L319
Doing this, reset the status flag before executing: https://github.com/uleroboticsgroup/yasmin/blob/983a0153057f98ccb95427d79a50610c43d4b3a5/yasmin/src/yasmin/state.cpp#L49

So I propose concurrency should do the same.

I didn't test the Python implementation, but there it seems correct already.

