### PR TITLE
Fix StateMachines cancels, waiting for states

### DIFF
--- a/yasmin/src/yasmin/state_machine.cpp
+++ b/yasmin/src/yasmin/state_machine.cpp
@@ -380,9 +380,9 @@ std::string StateMachine::operator()() {
 }
 
 void StateMachine::cancel_state() {
-  State::cancel_state();
 
   if (this->is_running()) {
+    State::cancel_state();
 
     auto current_state = this->get_current_state();
 

--- a/yasmin/yasmin/state_machine.py
+++ b/yasmin/yasmin/state_machine.py
@@ -448,9 +448,9 @@ class StateMachine(State):
 
         Overrides the cancel_state method from the parent State class.
         """
-        super().cancel_state()
 
         if self.is_running():
+            super().cancel_state()
             current_state = self.get_current_state()
 
             while not current_state:


### PR DESCRIPTION
The intention of this commit was to let a StateMachine wait for its state to cancel:
https://github.com/uleroboticsgroup/yasmin/commit/d6c7da6bbbdebfee120a8aeee11e4dfa0545ddf8#diff-e3d319293f1b2c82f3bcbb903b7535902fe335f2665084bde7477584dcfbf249

However, in the implementation the underlying `State::cancel_state();` is called first.
Hence, the check `if (this->is_running()) {` on the next line is directly false and thus the StateMachine will never ask it's states to cancel.

Simply swapping statements fixes this.