### PR TITLE
fix(validate): destroy state machine explicitly before returning

### DIFF
--- a/yasmin_cli/yasmin_cli/verb/validate.py
+++ b/yasmin_cli/yasmin_cli/verb/validate.py
@@ -82,6 +82,8 @@ def _validate_xml_file(xml_file: str, strict_mode: bool) -> tuple[bool, str]:
         factory = YasminFactory()
         state_machine = factory.create_sm_from_file(xml_file)
         state_machine.validate(strict_mode=strict_mode)
+        del state_machine
+        del factory
         return True, "OK"
     except Exception as exc:
         return False, str(exc)


### PR DESCRIPTION
This PR fixes a segmentation fault that occurred when validating certain XML state machines with:

```bash
ros2 yasmin validate src/yasmin_editor/test/runtime_test.xml 
Segmentation fault (core dumped)
```

The state_machine object is now explicitly destroyed immediately after validation. This change does not alter the validation logic itself.