### PR TITLE
Add missing include

### DIFF
--- a/yasmin_factory/src/yasmin_factory.cpp
+++ b/yasmin_factory/src/yasmin_factory.cpp
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "ament_index_cpp/get_package_share_directory.hpp"
 #include <algorithm>
 #include <cctype>
 #include <filesystem>


### PR DESCRIPTION
When building this in rolling, compilation fails with:

    src/yasmin_factory.cpp: In member function 'yasmin::StateMachine::SharedPtr yasmin_factory::YasminFactory::create_sm(tinyxml2::XMLElement*)':
    src/yasmin_factory.cpp:254:41: error: 'get_package_share_directory' is not a member of 'ament_index_cpp'
      254 |         package_path = ament_index_cpp::get_package_share_directory(package);
          |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Add the missing include file to fix the error.