### PR TITLE
Hide dot-prefixed blackboard keys by default and add toggle

### DIFF
--- a/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_blackboard_mixin.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_blackboard_mixin.py
@@ -30,10 +30,17 @@ class EditorBlackboardMixin:
     """Mixin for editor functionality split from the main window."""
 
     def filter_blackboard_keys(self, text: str) -> None:
-        """Filter blackboard keys based on search text."""
+        """Filter blackboard keys based on search text and visibility settings."""
+        filter_text = text.lower()
+        show_hidden = getattr(self, "_show_hidden_blackboard_keys", False)
+
         for i in range(self.blackboard_list.count()):
             item = self.blackboard_list.item(i)
-            item.setHidden(text.lower() not in item.text().lower())
+            key_data = item.data(Qt.UserRole) or {}
+            key_name = str(key_data.get("name", "") or "")
+            is_hidden_key = key_name.startswith(".")
+            matches_filter = filter_text in item.text().lower()
+            item.setHidden((not show_hidden and is_hidden_key) or not matches_filter)
 
     def format_blackboard_key_label(self, key_data: Dict[str, str]) -> str:
         label = f"{key_data.get('name', '')} ({key_data.get('key_type', 'in')})"
@@ -183,6 +190,13 @@ class EditorBlackboardMixin:
             "Highlight: On" if enabled else "Highlight: Off"
         )
         self.update_blackboard_usage_highlighting()
+
+    def toggle_hidden_blackboard_keys(self, enabled: bool) -> None:
+        self._show_hidden_blackboard_keys = enabled
+        self.show_hidden_blackboard_btn.setText(
+            "Hidden: On" if enabled else "Hidden: Off"
+        )
+        self.filter_blackboard_keys(self.blackboard_filter.text())
 
     def get_effective_blackboard_key_name(self, state_node, key_name: str) -> str:
         effective_key_name = key_name

--- a/yasmin_editor/yasmin_editor/editor_gui/ui/sidebars.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/ui/sidebars.py
@@ -73,6 +73,18 @@ def build_blackboard_widget(editor) -> QWidget:
     editor.highlight_blackboard_btn.setChecked(True)
     editor.highlight_blackboard_btn.toggled.connect(editor.toggle_blackboard_highlighting)
     button_row.addWidget(editor.highlight_blackboard_btn)
+
+    editor.show_hidden_blackboard_btn = QPushButton("Hidden: Off")
+    editor.show_hidden_blackboard_btn.setCheckable(True)
+    editor.show_hidden_blackboard_btn.setChecked(False)
+    editor.show_hidden_blackboard_btn.toggled.connect(
+        editor.toggle_hidden_blackboard_keys
+    )
+    editor.show_hidden_blackboard_btn.setToolTip(
+        'Blackboard keys starting with "." are hidden by default.'
+    )
+    button_row.addWidget(editor.show_hidden_blackboard_btn)
+
     layout.addLayout(button_row)
 
     return widget

--- a/yasmin_editor/yasmin_editor/editor_gui/yasmin_editor.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/yasmin_editor.py
@@ -72,6 +72,7 @@ class YasminEditor(
         self._blackboard_keys: List[Dict[str, str]] = []
         self._blackboard_key_metadata: Dict[str, Dict[str, str]] = {}
         self._highlight_blackboard_usage = True
+        self._show_hidden_blackboard_keys = False
 
         self.layout_seed = 42
         self.layout_rng = random.Random(self.layout_seed)


### PR DESCRIPTION
This PR hides blackboard keys starting with `.` from the left sidebar by default and adds a toggle button to show or hide them when needed. It also adds a tooltip to clarify that dot-prefixed keys are treated as hidden.

This only affects the visualization in the editor, the keys still exist and behave normally.