### PR TITLE
Refactor blackboard storage to isolate remappings in concurrence

### DIFF
--- a/yasmin/include/yasmin/blackboard.hpp
+++ b/yasmin/include/yasmin/blackboard.hpp
@@ -66,13 +66,25 @@ inline std::string demangle_type(const std::string &mangled_name) {
  */
 class Blackboard {
 private:
-  /// Mutex for thread safety.
-  mutable std::recursive_mutex mutex;
-  /// Storage for key-value pairs.
-  std::unordered_map<std::string, std::shared_ptr<void>> values;
-  /// Storage for type information for each key.
-  TypeRegistry type_registry;
-  /// Storage for key remappings.
+  /**
+   * @brief Shared storage used by blackboard copies.
+   *
+   * Values, type information and the synchronization primitive are shared so
+   * copied blackboards can access the same underlying data while keeping their
+   * own remapping scope.
+   */
+  struct SharedStorage {
+    /// Mutex for thread safety of the shared storage.
+    mutable std::recursive_mutex mutex;
+    /// Storage for key-value pairs.
+    std::unordered_map<std::string, std::shared_ptr<void>> values;
+    /// Storage for type information for each key.
+    TypeRegistry type_registry;
+  };
+
+  /// Shared storage for key-value pairs and type information.
+  std::shared_ptr<SharedStorage> storage;
+  /// Storage for key remappings local to this blackboard handle.
   Remappings remappings;
 
   /** @brief Internal method that acquires the maped key. In the case the key is
@@ -95,6 +107,9 @@ public:
   /**
    * @brief Copy constructor for Blackboard.
    * @param other The instance to copy from.
+   *
+   * The copied blackboard shares the underlying storage with @p other while
+   * keeping its own local remapping table.
    */
   Blackboard(const Blackboard &other);
 
@@ -108,20 +123,21 @@ public:
 
     YASMIN_LOG_DEBUG("Setting '%s' in the blackboard", name.c_str());
 
-    std::lock_guard<std::recursive_mutex> lk(this->mutex);
+    std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
 
     // Apply remapping if exists
     const std::string &key = this->remap(name);
     const std::string type_name = demangle_type(typeid(T).name());
 
-    auto type_it = this->type_registry.find(key);
-    if (type_it != this->type_registry.end() && type_it->second == type_name) {
+    auto type_it = this->storage->type_registry.find(key);
+    if (type_it != this->storage->type_registry.end() &&
+        type_it->second == type_name) {
       // Same type: update existing value in-place (avoids allocation)
-      *(std::static_pointer_cast<T>(this->values.at(key))) = value;
+      *(std::static_pointer_cast<T>(this->storage->values.at(key))) = value;
     } else {
       // New key or different type: (re)create entry
-      this->values[key] = std::make_shared<T>(value);
-      this->type_registry[key] = type_name;
+      this->storage->values[key] = std::make_shared<T>(value);
+      this->storage->type_registry[key] = type_name;
     }
   }
 
@@ -136,7 +152,7 @@ public:
 
     YASMIN_LOG_DEBUG("Getting '%s' from the blackboard", key.c_str());
 
-    std::lock_guard<std::recursive_mutex> lk(this->mutex);
+    std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
 
     // Check if the key exists
     if (!this->contains(key)) {
@@ -145,7 +161,8 @@ public:
     }
 
     // Return the value casted to the requested type
-    return *(std::static_pointer_cast<T>(this->values.at(this->remap(key))));
+    return *(std::static_pointer_cast<T>(
+        this->storage->values.at(this->remap(key))));
   }
 
   /**

--- a/yasmin/src/yasmin/blackboard.cpp
+++ b/yasmin/src/yasmin/blackboard.cpp
@@ -27,27 +27,27 @@
 
 using namespace yasmin;
 
-Blackboard::Blackboard() = default;
+Blackboard::Blackboard() : storage(std::make_shared<SharedStorage>()) {}
 
 Blackboard::Blackboard(const Blackboard &other)
-    : values(other.values), type_registry(other.type_registry),
-      remappings(other.remappings) {}
+    : storage(other.storage), remappings(other.remappings) {}
 
 void Blackboard::remove(const std::string &key) {
   YASMIN_LOG_DEBUG("Removing '%s' from the blackboard", key.c_str());
 
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
   auto remapped_key = this->remap(key);
-  this->values.erase(remapped_key);
-  this->type_registry.erase(remapped_key);
+  this->storage->values.erase(remapped_key);
+  this->storage->type_registry.erase(remapped_key);
 }
 
 bool Blackboard::contains(const std::string &key) const {
   YASMIN_LOG_DEBUG("Checking if '%s' is in the blackboard", key.c_str());
 
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
   auto remapped_key = this->remap(key);
-  return (this->values.find(remapped_key) != this->values.end());
+  return (this->storage->values.find(remapped_key) !=
+          this->storage->values.end());
 }
 
 void Blackboard::copy_value_from(const Blackboard &other,
@@ -56,46 +56,66 @@ void Blackboard::copy_value_from(const Blackboard &other,
   YASMIN_LOG_DEBUG("Copying '%s' from blackboard into '%s'", source_key.c_str(),
                    target_key.c_str());
 
-  std::scoped_lock<std::recursive_mutex, std::recursive_mutex> lk(this->mutex,
-                                                                  other.mutex);
+  if (this->storage == other.storage) {
+    std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
+
+    const std::string &remapped_source_key = other.remap(source_key);
+    if (other.storage->values.find(remapped_source_key) ==
+        other.storage->values.end()) {
+      throw std::runtime_error("Element '" + source_key +
+                               "' does not exist in the blackboard");
+    }
+
+    const std::string &remapped_target_key = this->remap(target_key);
+    this->storage->values[remapped_target_key] =
+        other.storage->values.at(remapped_source_key);
+    this->storage->type_registry[remapped_target_key] =
+        other.storage->type_registry.at(remapped_source_key);
+    return;
+  }
+
+  std::scoped_lock<std::recursive_mutex, std::recursive_mutex> lk(
+      this->storage->mutex, other.storage->mutex);
 
   const std::string &remapped_source_key = other.remap(source_key);
-  if (other.values.find(remapped_source_key) == other.values.end()) {
+  if (other.storage->values.find(remapped_source_key) ==
+      other.storage->values.end()) {
     throw std::runtime_error("Element '" + source_key +
                              "' does not exist in the blackboard");
   }
 
   const std::string &remapped_target_key = this->remap(target_key);
-  this->values[remapped_target_key] = other.values.at(remapped_source_key);
-  this->type_registry[remapped_target_key] =
-      other.type_registry.at(remapped_source_key);
+  this->storage->values[remapped_target_key] =
+      other.storage->values.at(remapped_source_key);
+  this->storage->type_registry[remapped_target_key] =
+      other.storage->type_registry.at(remapped_source_key);
 }
 
 int Blackboard::size() const {
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
-  return this->values.size();
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
+  return this->storage->values.size();
 }
 
 std::vector<std::string> Blackboard::keys() const {
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
 
   std::unordered_map<std::string, std::vector<std::string>>
       visible_keys_by_target;
   visible_keys_by_target.reserve(this->remappings.size());
 
   for (const auto &[visible_key, target_key] : this->remappings) {
-    if (this->values.find(target_key) != this->values.end()) {
+    if (this->storage->values.find(target_key) != this->storage->values.end()) {
       visible_keys_by_target[target_key].push_back(visible_key);
     }
   }
 
   std::vector<std::string> result;
-  result.reserve(this->values.size() + this->remappings.size());
+  result.reserve(this->storage->values.size() + this->remappings.size());
 
   std::unordered_set<std::string> inserted_keys;
-  inserted_keys.reserve(this->values.size() + this->remappings.size());
+  inserted_keys.reserve(this->storage->values.size() + this->remappings.size());
 
-  for (const auto &[stored_key, _] : this->values) {
+  for (const auto &[stored_key, _] : this->storage->values) {
     const auto visible_it = visible_keys_by_target.find(stored_key);
 
     if (visible_it == visible_keys_by_target.end()) {
@@ -119,7 +139,7 @@ std::vector<std::string> Blackboard::keys() const {
 std::string Blackboard::get_type(const std::string &key) const {
   YASMIN_LOG_DEBUG("Getting type of '%s' from the blackboard", key.c_str());
 
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
   auto remapped_key = this->remap(key);
 
   // Check if the key exists
@@ -128,18 +148,18 @@ std::string Blackboard::get_type(const std::string &key) const {
                              "' does not exist in the blackboard");
   }
 
-  return this->type_registry.at(remapped_key);
+  return this->storage->type_registry.at(remapped_key);
 }
 
 std::string Blackboard::to_string() const {
-  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  std::lock_guard<std::recursive_mutex> lk(this->storage->mutex);
 
   std::string result = "Blackboard\n";
 
   // Iterate through all key-value pairs and append to the result string
-  for (const auto &ele : this->values) {
-    result +=
-        "\t" + ele.first + " (" + this->type_registry.at(ele.first) + ")\n";
+  for (const auto &ele : this->storage->values) {
+    result += "\t" + ele.first + " (" +
+              this->storage->type_registry.at(ele.first) + ")\n";
   }
 
   return result;

--- a/yasmin/src/yasmin/concurrence.cpp
+++ b/yasmin/src/yasmin/concurrence.cpp
@@ -154,11 +154,22 @@ std::string Concurrence::execute(Blackboard::SharedPtr blackboard) {
   this->configure();
   std::vector<std::thread> state_threads;
 
-  // Initialize the parallel execution of all the states
+  // Reset stored intermediate outcomes before starting a new execution.
+  for (auto &[state_name, intermediate_outcome] :
+       this->intermediate_outcome_map) {
+    (void)state_name;
+    intermediate_outcome.clear();
+  }
+
+  // Initialize the parallel execution of all the states.
+  // Each branch receives a blackboard copy that shares the underlying storage
+  // but keeps an isolated remapping scope.
   for (const auto &[state_name, state] : states) {
+    Blackboard::SharedPtr thread_blackboard =
+        std::make_shared<Blackboard>(*blackboard);
     state_threads.push_back(std::thread([this, state_name, state,
-                                         blackboard]() {
-      std::string outcome = (*state.get())(blackboard);
+                                         thread_blackboard]() {
+      std::string outcome = (*state.get())(thread_blackboard);
       const std::lock_guard<std::mutex> lock(this->intermediate_outcome_mutex);
       this->intermediate_outcome_map[state_name] = outcome;
     }));

--- a/yasmin/test/test_blackboard.cpp
+++ b/yasmin/test/test_blackboard.cpp
@@ -84,6 +84,37 @@ TEST_F(TestBlackboard, TestKeysWithRemappingsExposeVisibleScope) {
   EXPECT_EQ(keys.at(2), "second");
 }
 
+TEST_F(TestBlackboard,
+       TestCopiedBlackboardSharesStorageAndKeepsRemappingsLocal) {
+  blackboard.set<int>("shared", 1);
+  blackboard.set_remappings({{"from_original", "shared"}});
+
+  Blackboard copied_blackboard(blackboard);
+  copied_blackboard.set_remappings({{"from_copy", "shared"}});
+
+  EXPECT_TRUE(blackboard.contains("from_original"));
+  EXPECT_FALSE(blackboard.contains("from_copy"));
+  EXPECT_TRUE(copied_blackboard.contains("from_copy"));
+  EXPECT_FALSE(copied_blackboard.contains("from_original"));
+
+  copied_blackboard.set<int>("from_copy", 42);
+
+  EXPECT_EQ(blackboard.get<int>("from_original"), 42);
+  EXPECT_EQ(blackboard.get<int>("shared"), 42);
+  EXPECT_EQ(copied_blackboard.get<int>("from_copy"), 42);
+}
+
+TEST_F(TestBlackboard, TestCopyValueFromWorksAcrossCopiedBlackboards) {
+  blackboard.set<std::string>("source", "value");
+  Blackboard copied_blackboard(blackboard);
+  copied_blackboard.set_remappings({{"copy_target", "target"}});
+
+  copied_blackboard.copy_value_from(blackboard, "source", "copy_target");
+
+  EXPECT_EQ(blackboard.get<std::string>("target"), "value");
+  EXPECT_EQ(copied_blackboard.get<std::string>("copy_target"), "value");
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/yasmin/test/test_concurrence.cpp
+++ b/yasmin/test/test_concurrence.cpp
@@ -16,6 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <condition_variable>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -24,6 +26,7 @@
 #include "yasmin/blackboard.hpp"
 #include "yasmin/concurrence.hpp"
 #include "yasmin/state.hpp"
+#include "yasmin/state_machine.hpp"
 #include "yasmin/types.hpp"
 
 using namespace yasmin;
@@ -135,4 +138,164 @@ TEST_F(TestConcurrence, TestConfigureAppliesParameterMappingsAndRunsOnce) {
   EXPECT_EQ((*concurrent)(blackboard), "done");
   EXPECT_EQ(child->configure_count, 1);
   EXPECT_EQ(child->configured_topic, "/concurrent");
+}
+
+struct ConcurrentWriteSync {
+  std::mutex mutex;
+  std::condition_variable condition;
+  int ready_count{0};
+  bool release_writes{false};
+};
+
+/**
+ * @brief State that waits until both concurrent branches are ready and then
+ * writes a value through the remapped blackboard key.
+ *
+ * The barrier is used to make both branches perform their write while both
+ * nested state machines are active. This makes remapping interference visible
+ * if the remapping context is shared between concurrent branches.
+ */
+class BlockingWriteState : public State {
+public:
+  BlockingWriteState(std::shared_ptr<ConcurrentWriteSync> sync,
+                     const std::string &value)
+      : State({"done"}), sync(std::move(sync)), value(value) {}
+
+  std::string execute(yasmin::Blackboard::SharedPtr blackboard) override {
+    {
+      // Wait here until both branches have entered execute().
+      // This ensures both writes happen while the concurrence container is
+      // running both nested state machines at the same time.
+      std::unique_lock<std::mutex> lock(this->sync->mutex);
+      this->sync->ready_count++;
+      this->sync->condition.notify_all();
+      this->sync->condition.wait(
+          lock, [this]() { return this->sync->release_writes; });
+    }
+
+    // Write through the remapped key. The final storage key depends on the
+    // remapping chain of the current branch.
+    blackboard->set<std::string>("foo_str", this->value);
+    return "done";
+  }
+
+private:
+  std::shared_ptr<ConcurrentWriteSync> sync;
+  std::string value;
+};
+
+/**
+ * @brief Small helper state machine that delays its start.
+ *
+ * The delay makes the scheduling of the two concurrent branches less symmetric,
+ * which helps to reproduce bugs caused by shared remapping state.
+ */
+class DelayedStartStateMachine : public StateMachine {
+public:
+  explicit DelayedStartStateMachine(std::chrono::milliseconds start_delay)
+      : StateMachine({"done"}), start_delay(start_delay) {}
+
+  std::string execute(yasmin::Blackboard::SharedPtr blackboard) override {
+    std::this_thread::sleep_for(this->start_delay);
+    return StateMachine::execute(blackboard);
+  }
+
+private:
+  std::chrono::milliseconds start_delay;
+};
+
+/**
+ * @brief Build one concurrent branch consisting of two nested remapping levels.
+ *
+ * Layout:
+ *   outer state machine: inner_key -> final_key
+ *   inner state machine: foo_str   -> inner_key
+ *
+ * The leaf state always writes to "foo_str". The nested remappings should make
+ * that value appear only under final_key in the shared blackboard.
+ */
+static yasmin::StateMachine::SharedPtr
+make_nested_branch(const std::shared_ptr<ConcurrentWriteSync> &sync,
+                   const std::string &inner_key, const std::string &final_key,
+                   const std::string &value,
+                   std::chrono::milliseconds start_delay) {
+  auto outer_state_machine =
+      std::make_shared<DelayedStartStateMachine>(start_delay);
+  auto inner_state_machine =
+      std::make_shared<yasmin::StateMachine>(yasmin::Outcomes{"done"});
+
+  inner_state_machine->add_state(
+      "WRITE", std::make_shared<BlockingWriteState>(sync, value),
+      yasmin::Transitions{{"done", "done"}},
+      yasmin::Remappings{{"foo_str", inner_key}});
+
+  outer_state_machine->add_state("INNER", inner_state_machine,
+                                 yasmin::Transitions{{"done", "done"}},
+                                 yasmin::Remappings{{inner_key, final_key}});
+
+  return outer_state_machine;
+}
+
+/**
+ * @brief Verify that concurrent nested state machines keep remappings isolated.
+ *
+ * Each branch has its own nested remapping chain:
+ *   Branch A: foo_str -> foo_inner_a -> foo_branch_a
+ *   Branch B: foo_str -> foo_inner_b -> foo_branch_b
+ *
+ * Both branches run at the same time and write through "foo_str". If remapping
+ * state is still shared globally, one branch can overwrite the remapping
+ * context of the other and the values may end up under the wrong keys.
+ *
+ * The expected behavior is:
+ * - each final branch key gets its own value
+ * - no intermediate remapping keys remain visible
+ * - the original key "foo_str" is not stored directly
+ */
+TEST_F(TestConcurrence,
+       TestConcurrentNestedStateMachinesKeepRemappingsIsolatedPerBranch) {
+  auto sync = std::make_shared<ConcurrentWriteSync>();
+
+  // Build two concurrent branches with different nested remapping chains.
+  auto branch_a = make_nested_branch(sync, "foo_inner_a", "foo_branch_a",
+                                     "value_a", std::chrono::milliseconds(0));
+  auto branch_b = make_nested_branch(sync, "foo_inner_b", "foo_branch_b",
+                                     "value_b", std::chrono::milliseconds(50));
+
+  auto concurrent = yasmin::Concurrence::make_shared(
+      yasmin::StateMap{{"BRANCH_A", branch_a}, {"BRANCH_B", branch_b}},
+      "failed",
+      yasmin::OutcomeMap{
+          {"done", {{"BRANCH_A", "done"}, {"BRANCH_B", "done"}}}});
+
+  // Execute the concurrence container asynchronously so the test thread can
+  // control when both branches are released to perform their writes.
+  auto future = std::async(std::launch::async, [concurrent, this]() {
+    return (*concurrent)(blackboard);
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(sync->mutex);
+
+    // Wait until both leaf states are inside execute(). This guarantees that
+    // the two writes happen while both branches are active.
+    sync->condition.wait(lock, [sync]() { return sync->ready_count == 2; });
+
+    // Release both branches together.
+    sync->release_writes = true;
+  }
+  sync->condition.notify_all();
+
+  EXPECT_EQ(future.get(), "done");
+
+  // Each branch must write to its own final remapped key.
+  EXPECT_EQ(blackboard->get<std::string>("foo_branch_a"), "value_a");
+  EXPECT_EQ(blackboard->get<std::string>("foo_branch_b"), "value_b");
+
+  // Intermediate remapping keys must not leak into the final blackboard.
+  EXPECT_FALSE(blackboard->contains("foo_inner_a"));
+  EXPECT_FALSE(blackboard->contains("foo_inner_b"));
+
+  // The original source key must also not exist in the final blackboard.
+  EXPECT_FALSE(blackboard->contains("foo_str"));
 }


### PR DESCRIPTION
This PR fixes remapping handling in `Concurrence`.

Right now remappings are stored in the shared `Blackboard`, which can cause concurrent branches with nested state machines to overwrite each other’s remapping context.

The fix keeps the blackboard data shared, but makes remappings local to each `Blackboard` instance. `Concurrence` now creates one blackboard copy per branch, so branches still share the same data but no longer interfere through remappings.

It also adds tests for blackboard duplication and for nested state machines with different remappings inside a `Concurrence`.
