### PR TITLE
Fix renaming states inside entered nested containers

### DIFF
--- a/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_model_mixin.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_model_mixin.py
@@ -261,8 +261,14 @@ class EditorModelMixin:
     def _rename_state_node(self, state_node, new_name: str) -> None:
         old_name = state_node.name
         parent_container = getattr(state_node, "parent_container", None)
+        # When editing inside an entered nested container, child nodes do not
+        # have a graphical parent container attached. In that case the rename
+        # must still be applied to the currently visible container model rather
+        # than to the root model.
         parent_model = (
-            self.root_model if parent_container is None else parent_container.model
+            self.current_container_model
+            if parent_container is None
+            else parent_container.model
         )
         old_prefix = self.get_state_node_key(old_name, parent_container)
         new_prefix = self.get_state_node_key(new_name, parent_container)


### PR DESCRIPTION
This fixes renaming states inside nested containers in the editor.

When editing a state inside an entered nested state machine, the node does not have a `parent_container`, so the old code incorrectly tried to rename the state in the root model. That caused a `KeyError` when renaming nested states.

The fix uses the current visible container model for renaming when no graphical parent container is set.