### PR TITLE
normalize cpp metadata types in editor and plugin cache path

### DIFF
--- a/yasmin_editor/yasmin_editor/editor_gui/dialogs/state_properties_dialog.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/dialogs/state_properties_dialog.py
@@ -241,15 +241,27 @@ class StatePropertiesDialog(QDialog):
             buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
+    @staticmethod
+    def _normalize_display_type(type_name: str) -> str:
+        """Normalize metadata type strings for user-facing display."""
+        normalized_type = str(type_name or "").strip()
+        if not normalized_type:
+            return ""
+
+        try:
+            return PluginInfo._normalize_cpp_metadata_type(normalized_type)
+        except Exception:
+            return normalized_type
+
     def _format_key_line(self, key_info: Dict[str, str], is_input: bool) -> str:
         key_name = str(key_info.get("name", "")).strip()
         key_desc = str(key_info.get("description", "")).strip()
-        key_type = str(
+        key_type = self._normalize_display_type(
             key_info.get(
                 "type",
                 key_info.get("default_value_type", key_info.get("default_type", "")),
             )
-        ).strip()
+        )
 
         line = key_name if key_name else "(unnamed)"
 
@@ -271,14 +283,14 @@ class StatePropertiesDialog(QDialog):
     def _format_parameter_line(self, parameter_info: Dict[str, str]) -> str:
         param_name = str(parameter_info.get("name", "")).strip()
         param_desc = str(parameter_info.get("description", "")).strip()
-        param_type = str(
+        param_type = self._normalize_display_type(
             parameter_info.get(
                 "type",
                 parameter_info.get(
                     "default_value_type", parameter_info.get("default_type", "")
                 ),
             )
-        ).strip()
+        )
         line = param_name if param_name else "(unnamed)"
         if param_desc:
             line += f": {param_desc}"

--- a/yasmin_plugins_manager/yasmin_plugins_manager/cache.py
+++ b/yasmin_plugins_manager/yasmin_plugins_manager/cache.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, Optional
 
 from ament_index_python import get_packages_with_prefixes
 
-CACHE_VERSION = 3
+CACHE_VERSION = 4
 IGNORE_PACKAGES_ENV_VAR = "YASMIN_DISCOVERY_IGNORE_PACKAGES"
 
 

--- a/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
+++ b/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
@@ -68,7 +68,7 @@ class PluginInfo:
             key_type = PluginInfo._normalize_cpp_metadata_type(map_match.group(1))
             value_type = PluginInfo._normalize_cpp_metadata_type(map_match.group(2))
             if key_type == "str" and value_type in {"str", "int", "float", "bool"}:
-                return f"dict[str,{value_type}]"
+                return f"dict[str, {value_type}]"
 
         return canonical_type
 
@@ -306,6 +306,14 @@ class PluginInfo:
         instance.input_keys = list(data.get("input_keys", []))
         instance.output_keys = list(data.get("output_keys", []))
         instance.parameters = list(data.get("parameters", []))
+
+        if instance.plugin_type == "cpp":
+            instance.input_keys = cls._normalize_cpp_metadata_entries(instance.input_keys)
+            instance.output_keys = cls._normalize_cpp_metadata_entries(
+                instance.output_keys
+            )
+            instance.parameters = cls._normalize_cpp_metadata_entries(instance.parameters)
+
         return instance
 
     @property

--- a/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
+++ b/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
@@ -27,26 +27,56 @@ class PluginInfo:
     """Store metadata of a discovered plugin."""
 
     @staticmethod
+    def _split_cpp_template_args(args: str) -> list[str]:
+        """Split a C++ template argument list at top-level commas."""
+        parts: list[str] = []
+        current: list[str] = []
+        depth = 0
+
+        for char in args:
+            if char == "<":
+                depth += 1
+                current.append(char)
+            elif char == ">":
+                depth = max(0, depth - 1)
+                current.append(char)
+            elif char == "," and depth == 0:
+                part = "".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+            else:
+                current.append(char)
+
+        tail = "".join(current).strip()
+        if tail:
+            parts.append(tail)
+
+        return parts
+
+    @staticmethod
     def _normalize_cpp_metadata_type(type_name: str) -> str:
         """Normalize common C++ metadata type names for user-facing output."""
-        normalized_type = type_name.strip()
+        normalized_type = " ".join(type_name.strip().split())
 
         string_fragment_pattern = re.compile(
-            r"std::(?:__cxx11::)?basic_string<char(?:,\s*std::char_traits<char>)?(?:,\s*std::allocator<char>\s*)?>"
-        )
-        string_type_pattern = re.compile(
-            r"^std::(?:__cxx11::)?basic_string<char(?:,\s*std::char_traits<char>)?(?:,\s*std::allocator<char>\s*)?>$"
+            r"std::(?:__cxx11::)?basic_string<char(?:,\s*std::char_traits<char>)?(?:,\s*std::allocator<char>)?\s*>"
         )
         integer_type_pattern = re.compile(
             r"^(unsigned\s+)?(short|int|long|long\s+long)(\s+int)?$"
         )
-        vector_pattern = re.compile(r"^std::vector<(.+?)>$")
-        map_pattern = re.compile(r"^std::unordered_map<\s*(.+?)\s*,\s*(.+?)\s*>$")
 
-        if normalized_type == "std::string" or string_type_pattern.match(normalized_type):
+        normalized_type = re.sub(r"\s*<\s*", "<", normalized_type)
+        normalized_type = re.sub(r"\s*>\s*", ">", normalized_type)
+        normalized_type = re.sub(r"\s*,\s*", ", ", normalized_type)
+
+        if normalized_type == "std::string":
             return "str"
 
         canonical_type = string_fragment_pattern.sub("std::string", normalized_type)
+
+        if canonical_type == "std::string":
+            return "str"
 
         if canonical_type == "bool":
             return "bool"
@@ -57,24 +87,52 @@ class PluginInfo:
         if integer_type_pattern.match(canonical_type):
             return "int"
 
-        vector_match = vector_pattern.match(canonical_type)
-        if vector_match:
-            element_type = PluginInfo._normalize_cpp_metadata_type(vector_match.group(1))
-            if element_type in {"str", "int", "float", "bool"}:
-                return f"list[{element_type}]"
+        if canonical_type.startswith("const "):
+            return PluginInfo._normalize_cpp_metadata_type(canonical_type[6:])
 
-        map_match = map_pattern.match(canonical_type)
-        if map_match:
-            key_type = PluginInfo._normalize_cpp_metadata_type(map_match.group(1))
-            value_type = PluginInfo._normalize_cpp_metadata_type(map_match.group(2))
-            if key_type == "str" and value_type in {"str", "int", "float", "bool"}:
-                return f"dict[str, {value_type}]"
+        if canonical_type.endswith("&"):
+            return PluginInfo._normalize_cpp_metadata_type(canonical_type[:-1].strip())
+
+        if canonical_type.endswith("*"):
+            pointee_type = PluginInfo._normalize_cpp_metadata_type(
+                canonical_type[:-1].strip()
+            )
+            return f"{pointee_type}*"
+
+        template_match = re.match(r"^([a-zA-Z0-9_:]+)<(.+)>$", canonical_type)
+        if not template_match:
+            return canonical_type
+
+        template_name = template_match.group(1)
+        template_args = PluginInfo._split_cpp_template_args(template_match.group(2))
+
+        if template_name == "std::vector" and len(template_args) >= 1:
+            element_type = PluginInfo._normalize_cpp_metadata_type(template_args[0])
+            return f"list[{element_type}]"
+
+        if (
+            template_name in {"std::unordered_map", "std::map"}
+            and len(template_args) >= 2
+        ):
+            key_type = PluginInfo._normalize_cpp_metadata_type(template_args[0])
+            value_type = PluginInfo._normalize_cpp_metadata_type(template_args[1])
+            return f"dict[{key_type}, {value_type}]"
+
+        if (
+            template_name in {"std::shared_ptr", "std::unique_ptr"}
+            and len(template_args) >= 1
+        ):
+            return PluginInfo._normalize_cpp_metadata_type(template_args[0])
+
+        if template_name == "std::optional" and len(template_args) >= 1:
+            value_type = PluginInfo._normalize_cpp_metadata_type(template_args[0])
+            return f"optional[{value_type}]"
 
         return canonical_type
 
     @classmethod
     def _normalize_cpp_metadata_entries(cls, metadata_entries: List[dict]) -> List[dict]:
-        """Normalize display types inside metadata dictionaries produced by C++ states."""
+        """Normalize display types inside metadata dictionaries for user-facing output."""
         normalized_entries: List[dict] = []
 
         for metadata_entry in metadata_entries:
@@ -249,22 +307,19 @@ class PluginInfo:
 
         try:
             self.input_keys = list(instance.get_input_keys())
-            if self.plugin_type == "cpp":
-                self.input_keys = self._normalize_cpp_metadata_entries(self.input_keys)
+            self.input_keys = self._normalize_cpp_metadata_entries(self.input_keys)
         except Exception:
             self.input_keys = []
 
         try:
             self.output_keys = list(instance.get_output_keys())
-            if self.plugin_type == "cpp":
-                self.output_keys = self._normalize_cpp_metadata_entries(self.output_keys)
+            self.output_keys = self._normalize_cpp_metadata_entries(self.output_keys)
         except Exception:
             self.output_keys = []
 
         try:
             self.parameters = list(instance.get_parameters())
-            if self.plugin_type == "cpp":
-                self.parameters = self._normalize_cpp_metadata_entries(self.parameters)
+            self.parameters = self._normalize_cpp_metadata_entries(self.parameters)
         except Exception:
             self.parameters = []
 

--- a/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
+++ b/yasmin_plugins_manager/yasmin_plugins_manager/plugin_info.py
@@ -362,12 +362,9 @@ class PluginInfo:
         instance.output_keys = list(data.get("output_keys", []))
         instance.parameters = list(data.get("parameters", []))
 
-        if instance.plugin_type == "cpp":
-            instance.input_keys = cls._normalize_cpp_metadata_entries(instance.input_keys)
-            instance.output_keys = cls._normalize_cpp_metadata_entries(
-                instance.output_keys
-            )
-            instance.parameters = cls._normalize_cpp_metadata_entries(instance.parameters)
+        instance.input_keys = cls._normalize_cpp_metadata_entries(instance.input_keys)
+        instance.output_keys = cls._normalize_cpp_metadata_entries(instance.output_keys)
+        instance.parameters = cls._normalize_cpp_metadata_entries(instance.parameters)
 
         return instance
 


### PR DESCRIPTION
This PR fixes the display of C++ metadata types in the YASMIN editor. Some states exposed demangled C++ types such as std::__cxx11::basic_string<...> or std::unordered_map<...> in the description view instead of user-friendly types.

The change applies the existing C++ type normalization logic consistently in the editor path and also normalizes cached plugin metadata in the plugins manager. 

With this change, types are shown in a cleaner form such as str, bool, int, float, list[...], and dict[str, str], which makes the generated state descriptions much easier to read.

Example:
```bash
ros2 yasmin info iki_yasmin/GenericSubscriberState 
Plugin:      iki_yasmin/GenericSubscriberState
Type:        cpp
Description: Subscribes to a ROS topic from runtime parameters and writes a shared GenericMessageStorage object to blackboard key 'msg_storage'. In background mode the subscription remains active after the state returns. In foreground mode the state waits for a message and then stops the subscription again.
Outcomes:
 - cancel: State execution was canceled while waiting for a message.
 - timeout: Foreground mode timed out before a suitable message was received.
 - error: Failed to create or use the generic ROS subscription.
 - success: The message storage was exposed successfully and, in foreground mode, a message was received.
Parameters:
  - topic [default='/text', type=str]
      Topic name used for the subscription.
  - type [default='std_msgs/msg/String', type=str]
      ROS interface type string such as 'std_msgs/msg/String'. The type is required to create the generic subscription.
  - qos [default={'depth': '10'}, type=dict[str, str]]
      QoS configuration encoded as a string dictionary. Supported keys are 'depth', 'durability', 'reliability' and 'history'.
  - background [default=False, type=bool]
      If true, keep the subscriber active after the state returns so the storage is updated continuously.
  - raw [default=False, type=bool]
      If true, keep serialized bytes as the stored payload. In the C++ generic subscriber implementation messages are received as serialized bytes anyway, so get_msg<MsgT>() performs lazy deserialization.
  - timeout [default=5.0, type=float]
      Timeout in seconds used in foreground mode while waiting for a new message. Values less than or equal to zero disable the timeout.
  - refresh_queue [default=True, type=bool]
      If true, discard the currently stored message when entering the state and wait for a fresh one.
Output keys:
  - msg_storage
      Thread-safe GenericMessageStorage shared pointer containing the latest received message. In C++ generic subscriptions store serialized bytes and later states can reconstruct a typed message via msg_storage->get_msg<MsgT>().

```