### PR TITLE
fix: create TfBufferState node during configure instead of constructor

### DIFF
--- a/yasmin_ros/src/yasmin_ros/tf_buffer_state.cpp
+++ b/yasmin_ros/src/yasmin_ros/tf_buffer_state.cpp
@@ -43,7 +43,7 @@ tf2::Duration to_tf_duration(const double seconds) {
 
 TfBufferState::TfBufferState()
     : yasmin::State({basic_outcomes::SUCCEED, basic_outcomes::ABORT}),
-      node_(YasminNode::get_instance()), cache_time_sec_(10.0) {
+      node_(nullptr), cache_time_sec_(10.0) {
   this->set_description(
       "Creates a shared tf2 buffer and transform listener and writes them to "
       "blackboard keys 'tf_buffer' and 'tf_listener'. Following states can "
@@ -67,6 +67,10 @@ TfBufferState::TfBufferState()
 
 void TfBufferState::configure() {
   this->cache_time_sec_ = this->get_parameter<double>("cache_time_sec");
+
+  if (!this->node_) {
+    this->node_ = YasminNode::get_instance();
+  }
 }
 
 std::string TfBufferState::execute(yasmin::Blackboard::SharedPtr blackboard) {

--- a/yasmin_ros/yasmin_ros/tf_buffer_state.py
+++ b/yasmin_ros/yasmin_ros/tf_buffer_state.py
@@ -33,7 +33,7 @@ class TfBufferState(State):
 
     def __init__(self) -> None:
         super().__init__([SUCCEED, ABORT])
-        self._node = YasminNode.get_instance()
+        self._node = None
         self._cache_time_sec = 10.0
 
         self.set_description(
@@ -64,6 +64,9 @@ class TfBufferState(State):
 
     def configure(self) -> None:
         self._cache_time_sec = float(self.get_parameter("cache_time_sec"))
+
+        if self._node is None:
+            self._node = YasminNode.get_instance()
 
     def execute(self, blackboard: Blackboard) -> str:
         try:


### PR DESCRIPTION
This PR moves the initialization of the yasmin node from the constructor to `configure()`. This avoids side effects during plugin instantiation and prevents intermittent plugin loading failures in the editor.