### PR TITLE
fix: store Python CallbackSignal as native shared_ptr across blackboard

### DIFF
--- a/yasmin/include/yasmin/blackboard_key_info_py.hpp
+++ b/yasmin/include/yasmin/blackboard_key_info_py.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "yasmin/blackboard_key_info.hpp"
+#include "yasmin/callback_signal_pyutils.hpp"
 #include "yasmin/callback_signal.hpp"
 #include "yasmin/state.hpp"
 #include "yasmin/types.hpp"
@@ -184,9 +185,10 @@ blackboard_key_info_from_pyobject(const std::string &key_name,
     return BlackboardKeyInfo(key_name, "", value.cast<std::string>());
   }
 
-  if (py::isinstance<yasmin::CallbackSignal::SharedPtr>(value)) {
-    return BlackboardKeyInfo(key_name, "",
-                             value.cast<yasmin::CallbackSignal::SharedPtr>());
+  if (yasmin::callback_signal_pyutils::is_python_callback_signal_like(value)) {
+    return BlackboardKeyInfo(
+        key_name, "",
+        yasmin::callback_signal_pyutils::cast_python_callback_signal(value));
   }
 
   if (is_python_sequence_like(value)) {

--- a/yasmin/include/yasmin/blackboard_key_info_py.hpp
+++ b/yasmin/include/yasmin/blackboard_key_info_py.hpp
@@ -27,8 +27,8 @@
 #include <vector>
 
 #include "yasmin/blackboard_key_info.hpp"
-#include "yasmin/callback_signal_pyutils.hpp"
 #include "yasmin/callback_signal.hpp"
+#include "yasmin/callback_signal_pyutils.hpp"
 #include "yasmin/state.hpp"
 #include "yasmin/types.hpp"
 

--- a/yasmin/include/yasmin/blackboard_pywrapper.hpp
+++ b/yasmin/include/yasmin/blackboard_pywrapper.hpp
@@ -29,6 +29,7 @@
 
 #include "yasmin/blackboard.hpp"
 #include "yasmin/callback_signal.hpp"
+#include "yasmin/callback_signal_pyutils.hpp"
 #include "yasmin/types.hpp"
 
 namespace py = pybind11;
@@ -329,9 +330,11 @@ public:
       return;
     }
 
-    if (py::isinstance<yasmin::CallbackSignal::SharedPtr>(value)) {
+    if (yasmin::callback_signal_pyutils::is_python_callback_signal_like(
+            value)) {
       this->blackboard->set<yasmin::CallbackSignal::SharedPtr>(
-          key, value.cast<yasmin::CallbackSignal::SharedPtr>());
+          key,
+          yasmin::callback_signal_pyutils::cast_python_callback_signal(value));
       return;
     }
 

--- a/yasmin/include/yasmin/callback_signal_pyutils.hpp
+++ b/yasmin/include/yasmin/callback_signal_pyutils.hpp
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Maik Knof
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef YASMIN__CALLBACK_SIGNAL_PYUTILS_HPP_
+#define YASMIN__CALLBACK_SIGNAL_PYUTILS_HPP_
+
+#include <pybind11/pybind11.h>
+
+#include <memory>
+#include <stdexcept>
+
+#include "yasmin/callback_signal.hpp"
+
+namespace py = pybind11;
+
+namespace yasmin {
+namespace callback_signal_pyutils {
+
+/**
+ * @brief Check whether a Python object is an instance of yasmin.CallbackSignal.
+ * @param value Python object to inspect.
+ * @return True if the object is a CallbackSignal instance.
+ *
+ * The check uses the exported Python class instead of relying on a holder-type
+ * based pybind11 isinstance check. This keeps the detection stable across the
+ * Python/C++ module boundary where the underlying object is bound with
+ * std::shared_ptr ownership.
+ */
+inline bool is_python_callback_signal_like(const py::handle &value) {
+  if (value.is_none()) {
+    return false;
+  }
+
+  try {
+#if PYBIND11_VERSION_MAJOR > 2 ||                                              \
+    (PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6)
+    py::module_ callback_signal_module =
+        py::module_::import("yasmin.callback_signal");
+#else
+    py::module callback_signal_module =
+        py::module::import("yasmin.callback_signal");
+#endif
+    py::object callback_signal_class =
+        callback_signal_module.attr("CallbackSignal");
+    const int is_instance =
+        PyObject_IsInstance(value.ptr(), callback_signal_class.ptr());
+
+    if (is_instance == 1) {
+      return true;
+    }
+
+    if (is_instance == -1) {
+      PyErr_Clear();
+    }
+  } catch (const py::error_already_set &) {
+    PyErr_Clear();
+  }
+
+  return false;
+}
+
+/**
+ * @brief Convert a Python CallbackSignal object into its native shared pointer.
+ * @param value Python object expected to hold a yasmin.CallbackSignal instance.
+ * @return Shared pointer to the native CallbackSignal.
+ * @throws std::runtime_error if the conversion fails.
+ */
+inline CallbackSignal::SharedPtr
+cast_python_callback_signal(const py::object &value) {
+  try {
+    return value.cast<CallbackSignal::SharedPtr>();
+  } catch (const py::cast_error &) {
+    throw std::runtime_error("Failed to convert Python CallbackSignal to "
+                             "std::shared_ptr<yasmin::CallbackSignal>");
+  }
+}
+
+} // namespace callback_signal_pyutils
+} // namespace yasmin
+
+#endif // YASMIN__CALLBACK_SIGNAL_PYUTILS_HPP_

--- a/yasmin/src/yasmin/blackboard_pybind11.cpp
+++ b/yasmin/src/yasmin/blackboard_pybind11.cpp
@@ -23,6 +23,13 @@ namespace py = pybind11;
 PYBIND11_MODULE(blackboard, m) {
   m.doc() = "Python bindings for yasmin::Blackboard";
 
+#if PYBIND11_VERSION_MAJOR > 2 ||                                              \
+    (PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6)
+  py::module_::import("yasmin.callback_signal");
+#else
+  py::module::import("yasmin.callback_signal");
+#endif
+
   py::class_<yasmin::BlackboardPyWrapper>(m, "Blackboard")
       .def(py::init<>())
       // Setters using set method and __setitem__/__setattr__

--- a/yasmin/src/yasmin/state_pybind11.cpp
+++ b/yasmin/src/yasmin/state_pybind11.cpp
@@ -135,6 +135,12 @@ PYBIND11_MODULE(state, m) {
   // This allows us to use it without re-registering the type
 #if PYBIND11_VERSION_MAJOR > 2 ||                                              \
     (PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6)
+  py::module_::import("yasmin.callback_signal");
+#else
+  py::module::import("yasmin.callback_signal");
+#endif
+#if PYBIND11_VERSION_MAJOR > 2 ||                                              \
+    (PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6)
   py::module_ blackboard_module = py::module_::import("yasmin.blackboard");
 #else
   py::module blackboard_module = py::module::import("yasmin.blackboard");


### PR DESCRIPTION
This change fixes the cross-language handling of `CallbackSignal` objects between Python and C++. Python-created signals are now stored in the blackboard as native `std::shared_ptr<yasmin::CallbackSignal>` instances, so C++ states can read and trigger them correctly.

It also ensures the callback-signal binding is loaded before blackboard and state conversion logic uses it, avoiding cases where the value falls back to a generic Python object. This makes the signal mechanism work reliably across the Python/C++ boundary as intended.