### PR TITLE
fix nested state machine transition scope in editor XML roundtrip

### DIFF
--- a/yasmin_editor/test/test_model_operations.py
+++ b/yasmin_editor/test/test_model_operations.py
@@ -273,3 +273,73 @@ def test_concurrence_xml_roundtrip_preserves_multiple_state_outcomes_per_final_o
     assert loaded_cc.outcome_map["finished"]["worker"] == ["ok", "retry"]
     assert xml_text.count('<Item state="worker" outcome="ok" />') == 1
     assert xml_text.count('<Item state="worker" outcome="retry" />') == 1
+
+
+def test_nested_state_machine_external_transitions_do_not_leak_into_same_named_child():
+    xml_text = """
+    <StateMachine name="root" outcomes="done" start_state="init">
+      <StateMachine name="init" outcomes="done" start_state="init">
+        <State name="init" type="py" module="demo.module" class="DemoState">
+          <Transition from="done" to="done" />
+        </State>
+        <FinalOutcome name="done" />
+        <Transition from="done" to="next" />
+      </StateMachine>
+      <State name="next" type="py" module="demo.module" class="DemoState">
+        <Transition from="done" to="done" />
+      </State>
+      <FinalOutcome name="done" />
+    </StateMachine>
+    """
+
+    root = model_from_xml(xml_text)
+    nested = root.get_state("init")
+
+    assert isinstance(nested, StateMachine)
+    assert [(item.source_outcome, item.target) for item in root.transitions["init"]] == [
+        ("done", "next")
+    ]
+    assert [
+        (item.source_outcome, item.target) for item in nested.transitions["init"]
+    ] == [("done", "done")]
+
+    serialized = model_to_xml(root)
+    nested_state_xml = serialized.split('<State name="init"', 1)[1].split("</State>", 1)[
+        0
+    ]
+    assert 'to="next"' not in nested_state_xml
+    assert '<Transition from="done" to="next" />' in serialized
+
+
+def test_corrupted_same_named_child_transition_to_parent_scope_is_removed_on_roundtrip():
+    xml_text = """
+    <StateMachine name="root" outcomes="done" start_state="init">
+      <StateMachine name="init" outcomes="done" start_state="init">
+        <State name="init" type="py" module="demo.module" class="DemoState">
+          <Transition from="done" to="done" />
+          <Transition from="done" to="next" />
+        </State>
+        <FinalOutcome name="done" />
+        <Transition from="done" to="next" />
+      </StateMachine>
+      <State name="next" type="py" module="demo.module" class="DemoState">
+        <Transition from="done" to="done" />
+      </State>
+      <FinalOutcome name="done" />
+    </StateMachine>
+    """
+
+    root = model_from_xml(xml_text)
+    nested = root.get_state("init")
+
+    assert isinstance(nested, StateMachine)
+    assert [
+        (item.source_outcome, item.target) for item in nested.transitions["init"]
+    ] == [("done", "done")]
+
+    serialized = model_to_xml(root)
+    nested_state_xml = serialized.split('<State name="init"', 1)[1].split("</State>", 1)[
+        0
+    ]
+    assert 'to="next"' not in nested_state_xml
+    assert serialized.count('<Transition from="done" to="next" />') == 1

--- a/yasmin_editor/yasmin_editor/io/xml_converter.py
+++ b/yasmin_editor/yasmin_editor/io/xml_converter.py
@@ -369,7 +369,11 @@ def _append_concurrence_outcome_map(
                 item_elem.set("outcome", state_outcome)
 
 
-def _parse_state_machine_container(element: ET.Element) -> StateMachine:
+def _parse_state_machine_container(
+    element: ET.Element,
+    *,
+    include_container_level_transitions: bool = True,
+) -> StateMachine:
     model = StateMachine(
         name=element.get("name", ""),
         description=element.get("description", ""),
@@ -380,7 +384,11 @@ def _parse_state_machine_container(element: ET.Element) -> StateMachine:
     model.keys.extend(_parse_keys(element.findall("Key")))
     model.parameter_mappings.update(_parse_parameter_remaps(element))
     model.remappings.update(_parse_remaps(element))
-    _parse_state_machine_content(model, element)
+    _parse_state_machine_content(
+        model,
+        element,
+        include_container_level_transitions=include_container_level_transitions,
+    )
     return model
 
 
@@ -402,10 +410,14 @@ def _parse_concurrence_container(element: ET.Element) -> Concurrence:
 def _parse_state_machine_content(
     model: StateMachine,
     element: ET.Element,
+    *,
+    include_container_level_transitions: bool,
 ) -> None:
     outcome_names = element.get("outcomes", "").split()
     for outcome_name in outcome_names:
         model.add_outcome(Outcome(name=outcome_name))
+
+    local_targets = _local_state_machine_targets(element)
 
     for child in element:
         if child.tag in {"Param", "Key", "ParamRemap", "Remap"}:
@@ -420,7 +432,8 @@ def _parse_state_machine_content(
             continue
 
         if child.tag == "Transition":
-            model.add_transition(model.name, _parse_transition(child))
+            if include_container_level_transitions:
+                model.add_transition(model.name, _parse_transition(child))
             continue
 
         if child.tag == "OutcomeMap":
@@ -435,7 +448,44 @@ def _parse_state_machine_content(
             model.layout.set_state_position(state.name, x, y)
 
         for transition_elem in child.findall("Transition"):
-            model.add_transition(state.name, _parse_transition(transition_elem))
+            transition = _parse_transition(transition_elem)
+            if _is_leaked_same_name_container_transition(
+                model,
+                state.name,
+                transition,
+                local_targets,
+            ):
+                continue
+            model.add_transition(state.name, transition)
+
+
+def _local_state_machine_targets(element: ET.Element) -> set[str]:
+    targets = set(element.get("outcomes", "").split())
+
+    for child in element:
+        if child.tag in {"State", "StateMachine", "Concurrence"}:
+            name = child.get("name", "")
+            if name:
+                targets.add(name)
+        elif child.tag == "FinalOutcome":
+            name = child.get("name", "")
+            if name:
+                targets.add(name)
+
+    return targets
+
+
+def _is_leaked_same_name_container_transition(
+    model: StateMachine,
+    state_name: str,
+    transition: Transition,
+    local_targets: set[str],
+) -> bool:
+    return (
+        state_name == model.name
+        and transition.target not in local_targets
+        and bool(transition.target)
+    )
 
 
 def _parse_concurrence_content(
@@ -546,7 +596,10 @@ def _parse_state_like(element: ET.Element) -> State:
         return _parse_concurrence_container(element)
 
     if element.tag == "StateMachine" and not element.get("file_name"):
-        return _parse_state_machine_container(element)
+        return _parse_state_machine_container(
+            element,
+            include_container_level_transitions=False,
+        )
 
     state = State(
         name=element.get("name", ""),


### PR DESCRIPTION
This PR fixes an editor XML roundtrip issue for nested state machines.

The bug appeared when an inline nested state machine had the same name as one of its child states, for example:

```xml
<StateMachine name="init" ...>
  <State name="init" ...>
```

In that case, transitions belonging to the nested state-machine container could be stored under the child state with the same name. After opening or saving the file in the editor, valid parent-scope transitions could be written into the child state.

This produced invalid XML where a child state inside the nested machine referenced a state from the outer machine.

The fix keeps container-level transitions and child-state transitions separated while parsing and serializing inline nested state machines. It also prevents already leaked invalid transitions from being preserved during load/save.

