### PR TITLE
Fix graphics item mobility with PyQt6

### DIFF
--- a/yasmin_editor/test/gui/test_editor_window_interactions.py
+++ b/yasmin_editor/test/gui/test_editor_window_interactions.py
@@ -218,3 +218,19 @@ def test_editor_window_updates_state_mobility(editor_window, qapp):
 
     state_node = editor.state_nodes["worker"]
     assert state_node.flags() & (QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
+
+
+def test_editor_window_finalizes_and_formats_text_block(editor_window, qapp):
+    editor = editor_window
+    editor.add_text_action.trigger()
+    qapp.processEvents()
+
+    text_block = editor.canvas.pending_placement_item
+    editor.finalize_pending_node_placement(text_block, text_block.pos())
+    text_block.text_item.setPlainText("")
+    text_block.text_item._wrap_selection("**", "**")
+
+    assert editor.canvas.pending_placement_item is None
+    assert text_block._is_editing
+    assert text_block.text_item.toPlainText() == "****"
+    assert text_block.text_item.textCursor().position() == 2

--- a/yasmin_editor/test/gui/test_editor_window_interactions.py
+++ b/yasmin_editor/test/gui/test_editor_window_interactions.py
@@ -20,6 +20,7 @@ pytest.importorskip("yasmin_editor.qt_compat")
 
 from yasmin_editor.qt_compat import Qt
 from yasmin_editor.qt_compat import QtTest
+from yasmin_editor.qt_compat import QtWidgets
 
 from gui_test_support import FakePluginInfo
 
@@ -203,3 +204,19 @@ def test_editor_window_pending_state_updates_start_state_selector(editor_window,
     assert "worker" not in editor.current_container_model.states
     assert editor.current_container_model.start_state is None
     assert editor.start_state_combo.currentText() == "(None)"
+
+
+def test_editor_window_updates_state_mobility(editor_window, qapp):
+    editor = editor_window
+    editor.create_state_node(
+        name="worker",
+        plugin_info=FakePluginInfo(module="demo_pkg.alpha", class_name="AlphaState"),
+    )
+    qapp.processEvents()
+
+    editor._set_scene_read_only_state()
+
+    state_node = editor.state_nodes["worker"]
+    assert state_node.flags() & (
+        QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIsMovable
+    )

--- a/yasmin_editor/test/gui/test_editor_window_interactions.py
+++ b/yasmin_editor/test/gui/test_editor_window_interactions.py
@@ -217,6 +217,4 @@ def test_editor_window_updates_state_mobility(editor_window, qapp):
     editor._set_scene_read_only_state()
 
     state_node = editor.state_nodes["worker"]
-    assert state_node.flags() & (
-        QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIsMovable
-    )
+    assert state_node.flags() & (QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIsMovable)

--- a/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_canvas_mixin.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_canvas_mixin.py
@@ -331,7 +331,9 @@ class EditorCanvasMixin:
     def _set_scene_read_only_state(self) -> None:
         readonly = self.is_read_only_mode()
         for item in list(self.state_nodes.values()) + list(self.final_outcomes.values()):
-            item.setFlag(item.ItemIsMovable, not readonly)
+            item.setFlag(
+                QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemIsMovable, not readonly
+            )
             if hasattr(item, "connection_port") and readonly:
                 item.connection_port.setVisible(False)
         for text_block in self.text_blocks:

--- a/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_ui_mixin.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/editor_mixin/editor_ui_mixin.py
@@ -18,6 +18,10 @@ from typing import Optional, Union
 from yasmin_editor.qt_compat import Qt, QtWidgets, exec_dialog
 from yasmin_editor.editor_gui.clipboard_model import is_container_empty
 from yasmin_editor.editor_gui.connection_line import ConnectionLine
+from yasmin_editor.editor_gui.container_metadata_logic import (
+    has_container_name_conflict,
+    normalize_container_name,
+)
 from yasmin_editor.editor_gui.dialog_result_adapters import (
     build_concurrence_kwargs,
     build_join_state_kwargs,

--- a/yasmin_editor/yasmin_editor/editor_gui/nodes/text_block_node.py
+++ b/yasmin_editor/yasmin_editor/editor_gui/nodes/text_block_node.py
@@ -71,7 +71,7 @@ class TextBlockEditorItem(QtWidgets.QGraphicsTextItem):
         else:
             cursor.insertText(f"{prefix}{suffix}")
             for _ in range(len(suffix)):
-                cursor.movePosition(QtGui.QTextCursor.Left)
+                cursor.movePosition(QtGui.QTextCursor.MoveOperation.Left)
             self.setTextCursor(cursor)
 
         self.node.update_geometry_from_document()
@@ -206,7 +206,7 @@ class TextBlockNode(BaseNodeMixin, QtWidgets.QGraphicsRectItem):
         self.update_content_view()
         self.text_item.setFocus(Qt.FocusReason.MouseFocusReason)
         cursor = self.text_item.textCursor()
-        cursor.movePosition(QtGui.QTextCursor.End)
+        cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
         self.text_item.setTextCursor(cursor)
 
     def finish_editing(self) -> None:


### PR DESCRIPTION
Fix a PyQt6 compatibility issue that caused the editor to crash when entering a nested state machine.

The movable graphics-item flag now uses the scoped Qt enum.

---

Fix editor crash when renaming the current container name in `Edit Current Container`