### PR TITLE
Declare yasmin_ros as an editor runtime dependency

### DIFF
--- a/yasmin_editor/package.xml
+++ b/yasmin_editor/package.xml
@@ -12,6 +12,7 @@
   <depend>yasmin</depend>
   <depend>yasmin_plugins_manager</depend>
   <depend>yasmin_factory</depend>
+  <exec_depend>yasmin_ros</exec_depend>
   <exec_depend>python3-tqdm</exec_depend>
   <!-- PyQt selection by Ubuntu version (threshold: resolute = 26):
        Ubuntu < 26 → python3-pyqt5,  Ubuntu >= 26 → python3-pyqt6


### PR DESCRIPTION
This PR declares `yasmin_ros` as an explicit runtime dependency of `yasmin_editor`.

After the editor event loop exits, `yasmin_editor/app.py` imports `YasminNode` directly from `yasmin_ros.yasmin_node` and calls
`YasminNode.destroy_instance()` to clean up ROS 2 resources.

Currently, `yasmin_ros` appears to be available transitively through `yasmin_factory` and `yasmin_viewer`. Adding an explicit runtime dependency makes the package manifest match the editor's direct runtime use.

This PR only adds:

```xml
<exec_depend>yasmin_ros</exec_depend>
```

No CMake change is needed because `yasmin_ros` is imported only while the installed Python application is running; it is not consumed during CMake configuration, compilation, or linking.
