### PR TITLE
Minimize boost dependencies as only headers are used during build

### DIFF
--- a/yasmin_viewer/package.xml
+++ b/yasmin_viewer/package.xml
@@ -8,8 +8,10 @@
   <license>Apache-2.0</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <build_depend>libboost-dev</build_depend>
+
+  <build_export_depend>libboost-dev</build_export_depend>
   <depend>ament_index_cpp</depend>
-  <depend>boost</depend>
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
   <depend>yasmin</depend>


### PR DESCRIPTION
Since the yasmin_viewer rewrite a full dependency on boost was added.
This means that in production deployments a full boost is installed.

However, only these header only files are used build-time:

```
#include <boost/asio.hpp>
#include <boost/beast/core.hpp>
#include <boost/beast/http.hpp>
#include <boost/beast/version.hpp>
```


So by solely installing libboost-dev as a build-depend, production deployments can be a lot smaller.