### PR TITLE
Allow remote connections to yasmin_viewer

### DIFF
--- a/yasmin_viewer/src/yasmin_viewer/yasmin_viewer_node.cpp
+++ b/yasmin_viewer/src/yasmin_viewer/yasmin_viewer_node.cpp
@@ -39,7 +39,7 @@
 namespace {
 
 std::string resolve_host(const std::string &host) {
-  if (host == "0.0.0.0" || host == "::" || host == "localhost") {
+  if (host == "localhost") {
     return "127.0.0.1";
   }
   return host;


### PR DESCRIPTION
I'm not sure what the reasoning was of returning "127.0.0.1" always, but setting a host to "0.0.0.0" typically means something very different: allow remote connections.

Forcing it to "127.0.0.1" means only local access, but it is very convenient to be able to remotely connect to a yasmin_viewer instance to debug a robot's behavior from my development pc. 
Hence, that's why we often set it to "host:=0.0.0.0", but lately this broke...